### PR TITLE
NoClear() Extension : fixes NPE Issue #1

### DIFF
--- a/orx-no-clear/src/main/kotlin/NoClear.kt
+++ b/orx-no-clear/src/main/kotlin/NoClear.kt
@@ -15,20 +15,22 @@ class NoClear : Extension {
 
 
     override fun beforeDraw(drawer: Drawer, program: Program) {
-        if (renderTarget == null || renderTarget?.width != program.width || renderTarget?.height != program.height) {
-            renderTarget?.let {
-                it.colorBuffer(0).destroy()
-                it.detachColorBuffers()
-                it.destroy()
-            }
-            renderTarget = renderTarget(program.width, program.height) {
-                colorBuffer()
-                depthBuffer()
-            }
+        if (program.width > 0 && program.height > 0) {    // only if the window is not minimised
+            if (renderTarget == null || renderTarget?.width != program.width || renderTarget?.height != program.height) {
+                renderTarget?.let {
+                    it.colorBuffer(0).destroy()
+                    it.detachColorBuffers()
+                    it.destroy()
+                }
+                renderTarget = renderTarget(program.width, program.height) {
+                    colorBuffer()
+                    depthBuffer()
+                }
 
-            renderTarget?.let {
-                drawer.withTarget(it) {
-                    background(program.backgroundColor ?: ColorRGBa.TRANSPARENT)
+                renderTarget?.let {
+                    drawer.withTarget(it) {
+                        background(program.backgroundColor ?: ColorRGBa.TRANSPARENT)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added a check for the case when the program window is minimised i.e. `width 0` and `height 0`.

The fail is on the create RenderTarget but I added the check to the broader context because it does not makes sense to delete any existing drawing buffers when the window is minimised i.e. the draw loop is still going at full tilt in the background even though the window is not visible.

Also, a window `size` event can result in one or both of these being set to 0. 