### PR TITLE
NoCLear() extension : provide a custom backdrop

### DIFF
--- a/orx-no-clear/README.md
+++ b/orx-no-clear/README.md
@@ -5,17 +5,48 @@ OPENRNDR does not support natively.
 
 #### Usage
 
-```
-class NoClearProgram: Program() {
-
-    override fun setup() {
+```kotlin
+fun main() = application {
+    configure {
+        title = "NoClearProgram"
+    }
+    program {
         backgroundColor = ColorRGBa.PINK
         extend(NoClear())
-    }
-
-    override fun draw() {
-        drawer.circle(Math.cos(seconds) * width / 2.0 + width / 2.0, Math.sin(seconds * 0.24) * height / 2.0 + height / 2.0, 20.0)
+        extend {
+            drawer.circle(Math.cos(seconds) * width / 2.0 + width / 2.0, Math.sin(seconds * 0.24) * height / 2.0 + height / 2.0, 20.0)
+        }
     }
 }
-
 ```
+
+#### Usage with a Lambda Expression Parameter 
+Optionally, the static backdrop may be initialised by passing a custom code block to the `NoClear()` function.
+
+- Example 1. Customising the backdrop with an image
+```kotlin
+val img = loadImage("file:data\\myImage.png")
+val bgImage = {
+        drawer.image(img, 0.0, 0.0, width * 1.0, height * 1.0)
+    }
+extend(NoClear(bgImage))
+```
+
+- Example 2. Customising the backdrop with a checker-board pattern
+```kotlin
+val bgBoard = {
+    val xw = width / 8.0
+    val yh = height / 8.0
+    drawer.fill = ColorRGBa.RED
+    (0..7).forEach { row ->
+        (0..7).forEach { col ->
+            if ((row + col) % 2 == 0) {
+                drawer.rectangle(row * xw, col * yh, xw, yh)
+            }
+        }
+    }
+}
+extend(NoClear(bgBoard))
+```
+
+NB! any submitted _lambda expression_ must be valid within the `renderTarget` context.

--- a/orx-no-clear/README.md
+++ b/orx-no-clear/README.md
@@ -20,33 +20,35 @@ fun main() = application {
 }
 ```
 
-#### Usage with a Lambda Expression Parameter 
-Optionally, the static backdrop may be initialised by passing a custom code block to the `NoClear()` function.
+#### Usage with additional configuration
+Optionally, a static `backdrop` may be setup by providing custom code.
 
 - Example 1. Customising the backdrop with an image
 ```kotlin
-val img = loadImage("file:data\\myImage.png")
-val bgImage = {
+extend(NoClear()) {
+    val img = loadImage("data\\backdrop.png")
+    backdrop = {
         drawer.image(img, 0.0, 0.0, width * 1.0, height * 1.0)
     }
-extend(NoClear(bgImage))
+}
 ```
 
 - Example 2. Customising the backdrop with a checker-board pattern
 ```kotlin
-val bgBoard = {
-    val xw = width / 8.0
-    val yh = height / 8.0
-    drawer.fill = ColorRGBa.RED
-    (0..7).forEach { row ->
-        (0..7).forEach { col ->
-            if ((row + col) % 2 == 0) {
-                drawer.rectangle(row * xw, col * yh, xw, yh)
+extend(NoClear()) {
+    backdrop = {
+        val xw = width / 8.0
+        val yh = height / 8.0
+        drawer.fill = ColorRGBa.RED
+        (0..7).forEach { row ->
+            (0..7).forEach { col ->
+                if ((row + col) % 2 == 0) {
+                    drawer.rectangle(row * xw, col * yh, xw, yh)
+                }
             }
         }
     }
 }
-extend(NoClear(bgBoard))
 ```
 
 NB! any submitted _lambda expression_ must be valid within the `renderTarget` context.

--- a/orx-no-clear/src/main/kotlin/NoClear.kt
+++ b/orx-no-clear/src/main/kotlin/NoClear.kt
@@ -9,9 +9,14 @@ import org.openrndr.draw.isolated
 import org.openrndr.draw.renderTarget
 import org.openrndr.math.Matrix44
 
-class NoClear(val block: (() -> Unit)? = null): Extension {
+class NoClear : Extension {
     override var enabled: Boolean = true
     private var renderTarget: RenderTarget? = null
+
+    /**
+     * code-block to draw an optional custom backdrop
+     */
+    var backdrop: (() -> Unit)? = null
 
     override fun beforeDraw(drawer: Drawer, program: Program) {
         if (program.width > 0 && program.height > 0) {    // only if the window is not minimised
@@ -29,7 +34,7 @@ class NoClear(val block: (() -> Unit)? = null): Extension {
                 renderTarget?.let {
                     drawer.withTarget(it) {
                         background(program.backgroundColor ?: ColorRGBa.TRANSPARENT)
-                        block?.invoke()
+                        backdrop?.invoke() // draw custom backdrop
                     }
                 }
             }

--- a/orx-no-clear/src/main/kotlin/NoClear.kt
+++ b/orx-no-clear/src/main/kotlin/NoClear.kt
@@ -9,10 +9,9 @@ import org.openrndr.draw.isolated
 import org.openrndr.draw.renderTarget
 import org.openrndr.math.Matrix44
 
-class NoClear : Extension {
+class NoClear(val block: (() -> Unit)? = null): Extension {
     override var enabled: Boolean = true
     private var renderTarget: RenderTarget? = null
-
 
     override fun beforeDraw(drawer: Drawer, program: Program) {
         if (program.width > 0 && program.height > 0) {    // only if the window is not minimised
@@ -30,6 +29,7 @@ class NoClear : Extension {
                 renderTarget?.let {
                     drawer.withTarget(it) {
                         background(program.backgroundColor ?: ColorRGBa.TRANSPARENT)
+                        block?.invoke()
                     }
                 }
             }


### PR DESCRIPTION
This is a enhancement to the `NoClear()` extension. This feature suppports the drawing of a custom backdrop if it is provided as a codeblock. 

This is a somewhat 'cleaner' alternative to managing the backdrop in the draw() loop.

_It is optional. The current functioning is not impacted._ 

## Notes for review
- use of lambda parameter 
- introduces the potential for issues with scope, visibility, etc 
- the onus is on coder to ensure lambda code is valid for this (RenderTarget) context.
- the intended use is quite simple as illustrated by the examples, but the coder could increase the complexity (leading to un-envisaged problems?).
- size events and associated 'scaling' is still the coder's responsibility.

## Limitations
- async loaded images may not yet be available on the first invocation.  Its kinda problematic because this will not be redrawn until the next 'refresh' (if it occurs!).

## ToDo
- the user/coder should be able to trigger a refresh of the backdrop.
