### PR TITLE
Add 1 parameter binding to OSC

### DIFF
--- a/orx-osc/src/main/kotlin/OSC.kt
+++ b/orx-osc/src/main/kotlin/OSC.kt
@@ -9,11 +9,13 @@ import com.illposed.osc.transport.udp.OSCPortOut
 import mu.KotlinLogging
 import java.net.InetAddress
 import java.net.PortUnreachableException
+import kotlin.reflect.KMutableProperty0
 
 private typealias OSCListener = Pair<OSCPatternAddressMessageSelector, OSCMessageListener>
 
 private val logger = KotlinLogging.logger {}
 
+@Suppress("unused")
 class OSC (
         val address: InetAddress = InetAddress.getLocalHost(),
         val portIn: Int = OSCPort.DEFAULT_SC_OSC_PORT,
@@ -50,6 +52,19 @@ class OSC (
 
         if (!receiver.isListening) this.startListening()
     }
+
+    infix fun String.bind(prop: KMutableProperty0<Double>) {
+        val channel = this
+
+        listen(channel) {
+            when (val message = it.first()) {
+                is Double -> prop.set(message)
+                is Float -> prop.set(message.toDouble())
+            }
+        }
+    }
+
+    fun listen(function: OSC.() -> Unit) = function()
 
     // Cannot be called inside a listener's callback
     fun removeListener(channel: String?) {


### PR DESCRIPTION
```kotlin
        val params = object {
            var track1: Double = 0.0
            var track2: Double = 0.0
        }

        osc.listen {
            "/track1" bind params::track1
            "/track2" bind params::track2
        }
```

Makes it easier to handle single events. Unfortunately, Generics is not my strong suit so I just created a method for Double which tends to be the most used type in our applications.