### PR TITLE
Prevent a crash when using a 'val' with a parameter annotation...

### DIFF
--- a/orx-parameters/src/main/kotlin/Annotations.kt
+++ b/orx-parameters/src/main/kotlin/Annotations.kt
@@ -125,6 +125,7 @@ class Parameter(
 fun Any.listParameters(): List<Parameter> {
     return (this::class.memberProperties.filter {
         !it.isConst &&
+                it is KMutableProperty1<*, *> &&
                 it.visibility == KVisibility.PUBLIC &&
                 it.annotations.map { it.annotationClass }.intersect(ParameterType.parameterAnnotationClasses).isNotEmpty()
     }.map {


### PR DESCRIPTION
It tried to cast an immutable to a mutable property...