### PR TITLE
Tweak orx-gui demos to produce better screenshots

### DIFF
--- a/orx-gui/src/demo/kotlin/DemoOptions01.kt
+++ b/orx-gui/src/demo/kotlin/DemoOptions01.kt
@@ -3,24 +3,24 @@ import org.openrndr.color.ColorRGBa
 import org.openrndr.extensions.SingleScreenshot
 import org.openrndr.extra.gui.GUI
 import org.openrndr.extra.parameters.*
-import org.openrndr.math.Vector2
 
 /**
- * A simple demonstration of a GUI for drawing a single circle
+ * A simple demonstration of a GUI with a drop down menu
  */
 
-enum class SomeOptions {
-    Default,
-    DoNothing,
-    Smile
+enum class BackgroundColors {
+    Pink,
+    Black,
+    Yellow
 }
 
 fun main() = application {
     program {
         val gui = GUI()
+        gui.compartmentsCollapsedByDefault = false
         val settings = @Description("Settings") object {
-            @OptionParameter("action")
-            var option = SomeOptions.Default
+            @OptionParameter("Background color")
+            var option = BackgroundColors.Pink
         }
 
         gui.add(settings)
@@ -32,9 +32,9 @@ fun main() = application {
         extend(gui)
         extend {
             when(settings.option) {
-                SomeOptions.Default -> drawer.background(ColorRGBa.PINK)
-                SomeOptions.DoNothing -> drawer.background(ColorRGBa.BLACK)
-                SomeOptions.Smile -> drawer.background(ColorRGBa.YELLOW)
+                BackgroundColors.Pink -> drawer.background(ColorRGBa.PINK)
+                BackgroundColors.Black -> drawer.background(ColorRGBa.BLACK)
+                BackgroundColors.Yellow -> drawer.background(ColorRGBa.YELLOW)
             }
         }
     }

--- a/orx-gui/src/demo/kotlin/DemoSimple01.kt
+++ b/orx-gui/src/demo/kotlin/DemoSimple01.kt
@@ -4,25 +4,28 @@ import org.openrndr.extensions.SingleScreenshot
 import org.openrndr.extra.gui.GUI
 import org.openrndr.extra.parameters.*
 import org.openrndr.math.Vector2
+import org.openrndr.shape.Circle
 
 /**
- * A simple demonstration of a GUI for drawing a single circle
+ * A simple demonstration of a GUI for drawing some circles
  */
 fun main() = application {
     program {
         val gui = GUI()
+        gui.compartmentsCollapsedByDefault = false
+
         val settings = @Description("Settings") object {
             @DoubleParameter("radius", 0.0, 100.0)
             var radius = 50.0
 
             @Vector2Parameter("position", 0.0, 1.0)
-            var position = Vector2.ZERO
+            var position = Vector2(0.6, 0.5)
 
             @ColorParameter("color")
             var color = ColorRGBa.PINK
 
-            @DoubleListParameter("a double list")
-            var adl = MutableList(2) { 0.0 }
+            @DoubleListParameter("radii", 5.0, 30.0)
+            var radii = mutableListOf(5.0, 6.0, 8.0, 14.0, 20.0, 30.0)
         }
         gui.add(settings)
         if (System.getProperty("takeScreenshot") == "true") {
@@ -34,6 +37,11 @@ fun main() = application {
         extend {
             drawer.fill = settings.color
             drawer.circle(settings.position * drawer.bounds.position(1.0, 1.0), settings.radius)
+            drawer.circles(
+                    settings.radii.mapIndexed { i, radius ->
+                        Circle(width - 50.0, 60.0 + i * 70.0, radius)
+                    }
+            )
         }
     }
 }


### PR DESCRIPTION
Do not collapse the guis so the demo screenshots show what's going on.

Do other changes for more understandable screenshots.