### PR TITLE
[orx-panel] trigger requestDraw when changing TextElement text

### DIFF
--- a/orx-panel/src/demo/kotlin/DemoHorizontalLayout01.kt
+++ b/orx-panel/src/demo/kotlin/DemoHorizontalLayout01.kt
@@ -7,9 +7,7 @@ import org.openrndr.panel.controlManager
 import org.openrndr.panel.elements.button
 import org.openrndr.panel.elements.div
 import org.openrndr.panel.elements.h1
-import org.openrndr.panel.elements.requestRedraw
 import org.openrndr.panel.style.*
-import kotlin.random.Random
 
 fun main() = application {
     program {
@@ -46,30 +44,30 @@ fun main() = application {
                             "twist", "swim", "roll", "fly", "dance")
                             .forEachIndexed { i, word ->
 
-                        // A fun way of generating a set of colors
-                        // of similar brightness:
-                        // Grab a point on the surface of a sphere
-                        // and treat its coordinates as an rgb color.
-                        val pos = Vector3.fromSpherical(
-                                Spherical(i * 19.0, i * 17.0, 0.4))
-                        val rgb = ColorRGBa.fromVector(pos + 0.4)
+                                // A fun way of generating a set of colors
+                                // of similar brightness:
+                                // Grab a point on the surface of a sphere
+                                // and treat its coordinates as an rgb color.
+                                val pos = Vector3.fromSpherical(
+                                        Spherical(i * 19.0, i * 17.0, 0.4))
+                                val rgb = ColorRGBa.fromVector(pos + 0.4)
 
-                        button {
-                            label = word
-                            style = styleSheet {
-                                // Use Color.RGBa() to convert a ColorRGBa
-                                // color (the standard color datatype)
-                                // into "CSS" format:
-                                background = Color.RGBa(rgb)
-                            }
+                                button {
+                                    label = word
+                                    style = styleSheet {
+                                        // Use Color.RGBa() to convert a ColorRGBa
+                                        // color (the standard color datatype)
+                                        // into "CSS" format:
+                                        background = Color.RGBa(rgb)
+                                    }
 
-                            // When the button is clicked replace
-                            // the header text with the button's label
-                            events.clicked.listen {
-                                header.replaceText(it.source.label)
+                                    // When the button is clicked replace
+                                    // the header text with the button's label
+                                    events.clicked.listen {
+                                        header.replaceText(it.source.label)
+                                    }
+                                }
                             }
-                        }
-                    }
                 }
             }
         }

--- a/orx-panel/src/demo/kotlin/DemoHorizontalLayout01.kt
+++ b/orx-panel/src/demo/kotlin/DemoHorizontalLayout01.kt
@@ -9,6 +9,7 @@ import org.openrndr.panel.elements.div
 import org.openrndr.panel.elements.h1
 import org.openrndr.panel.elements.requestRedraw
 import org.openrndr.panel.style.*
+import kotlin.random.Random
 
 fun main() = application {
     program {
@@ -66,7 +67,6 @@ fun main() = application {
                             // the header text with the button's label
                             events.clicked.listen {
                                 header.replaceText(it.source.label)
-                                header.requestRedraw()
                             }
                         }
                     }

--- a/orx-panel/src/main/kotlin/org/openrndr/panel/elements/TextElements.kt
+++ b/orx-panel/src/main/kotlin/org/openrndr/panel/elements/TextElements.kt
@@ -70,12 +70,14 @@ class P : TextElement(ElementType("p"))
 abstract class TextElement(et: ElementType) : Element(et) {
     fun text(text: String) {
         append(TextNode(text))
+        requestRedraw()
     }
     fun replaceText(text : String) {
         if (children.isEmpty()) {
             text(text)
         } else {
             (children.first() as? TextNode)?.text = text
+            requestRedraw()
         }
     }
 }


### PR DESCRIPTION
With this change, if a `Button` changes its own `label` on click, or if a `Button` changes another `TextElement` like an `h1` on click, it updates immediately without having to call `requestDraw()` manually.