### PR TITLE
Fix readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 A growing library of assorted data structures, algorithms and utilities.
 
 <!-- __orxListBegin__ -->
-| name | description |
+| name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | description |
+| --- | --- |
 | [`orx-boofcv`](orx-boofcv/README.md) | Helper functions to ease working with the BoofCV computer vision library and its data types. |
 | [`orx-camera`](orx-camera/README.md) | 3D camera controllable via mouse and keyboard. |
 | [`orx-compositor`](orx-compositor/README.md) | Toolkit to make composite (layered) images using blend modes and filters. |

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,8 @@ task buildMainReadme {
         for (line in header) {
             newReadme.add(line)
         }
-        newReadme.add("| name | description |")
+        newReadme.add("| name" + ("&nbsp;".repeat(36)) + " | description |")
+        newReadme.add("| --- | --- |")
 
         // Search for the description at the top of the readme.
         // Skip the hash character from the headline, then start


### PR DESCRIPTION
Was missing the headline/body separator.

Also add non breaking spaces to not wrap orx- names
