### PR TITLE
Make ColorCorrection clamped by default, add Boolean setting

### DIFF
--- a/orx-fx/src/main/kotlin/color/ColorCorrection.kt
+++ b/orx-fx/src/main/kotlin/color/ColorCorrection.kt
@@ -2,6 +2,7 @@ package org.openrndr.extra.fx.color
 
 import org.openrndr.draw.*
 import org.openrndr.extra.fx.filterFragmentUrl
+import org.openrndr.extra.parameters.BooleanParameter
 import org.openrndr.extra.parameters.Description
 import org.openrndr.extra.parameters.DoubleParameter
 
@@ -25,6 +26,9 @@ class ColorCorrection : Filter(filterShaderFromUrl(filterFragmentUrl("color/colo
     @DoubleParameter("opacity", 0.0, 1.0, order = 5)
     var opacity: Double by parameters
 
+    @BooleanParameter("clamp", order = 6)
+    var clamped: Boolean by parameters
+
     init {
         contrast = 0.0
         brightness = 0.0
@@ -32,5 +36,6 @@ class ColorCorrection : Filter(filterShaderFromUrl(filterFragmentUrl("color/colo
         hueShift = 0.0
         gamma = 1.0
         opacity = 1.0
+        clamped = true
     }
 }

--- a/orx-fx/src/main/resources/org/openrndr/extra/fx/gl3/color/color-correction.frag
+++ b/orx-fx/src/main/resources/org/openrndr/extra/fx/gl3/color/color-correction.frag
@@ -8,6 +8,7 @@ uniform float contrast;
 uniform float hueShift;
 uniform float gamma;
 uniform float opacity;
+uniform bool clamped;
 
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
@@ -61,5 +62,9 @@ void main() {
     nc.rgb = pow(nc.rgb, vec3(gamma));
     nc.rgb = shiftHue(nc.rgb, (hueShift/360.0));
     vec4 cc = brightnessMatrix(brightness) * contrastMatrix((contrast + 1)) * saturationMatrix(saturation + 1) * nc;
-    o_color = vec4(cc.rgb, 1.0) * color.a * opacity;
+    if(clamped) {
+        o_color = clamp(vec4(cc.rgb, 1.0) * color.a * opacity, 0.0, 1.0);
+    } else {
+        o_color = vec4(cc.rgb, 1.0) * color.a * opacity;
+    }
 }


### PR DESCRIPTION
Without this the filter can return negative or too high values (with floating point buffers) which can lead to unexpected results (like darker results with blend mode Add).