### PR TITLE
Enable automatic README generation

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -21,17 +21,17 @@ jobs:
       - name: Collect screenshots
         run: xvfb-run ./gradlew collectScreenshots
       - name: Build main readme
-        run: |
-          xvfb-run ./gradlew buildMainReadme
-          (git add README.md && git commit -m "add auto-generated README" && git push origin master) || true
+        run: xvfb-run ./gradlew buildMainReadme
       - name: Prepare media branch
         run: |
           git config --global user.email "actions@openrndr.org"
           git config --global user.name "OPENRNDR Actions"
           git reset HEAD -- .
+          (git add README.md && git commit -m "add auto-generated README" && git push origin master) || true
           (git add [a-z-]*/README.md && git commit -m "add demos to README.md" && git push origin master) || true
           git checkout --orphan media
           git reset HEAD -- .
           git add [a-z-]*/images/*.png
           git commit -m "add auto-generated media"
           git push -f origin media
+

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -20,6 +20,10 @@ jobs:
           xvfb-run glxinfo
       - name: Collect screenshots
         run: xvfb-run ./gradlew collectScreenshots
+      - name: Build main readme
+        run: |
+          xvfb-run ./gradlew buildMainReadme
+          (git add README.md && git commit -m "add auto-generated README" && git push origin master) || true
       - name: Prepare media branch
         run: |
           git config --global user.email "actions@openrndr.org"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A growing library of assorted data structures, algorithms and utilities.
 | --- | --- |
 | [`orx-boofcv`](orx-boofcv/README.md) | Helper functions to ease working with the BoofCV computer vision library and its data types. |
 | [`orx-camera`](orx-camera/README.md) | 3D camera controllable via mouse and keyboard. |
+| [`orx-chataigne`](orx-chataigne/README.md) | Expose variables to [Chataigne](http://benjamin.kuperberg.fr/chataigne/en) and any other applications that can interface with it. The current implementation makes use of the OSC protocol and supports `Double` and `ColorRGBa`. |
 | [`orx-compositor`](orx-compositor/README.md) | Toolkit to make composite (layered) images using blend modes and filters. |
+| [`orx-dnk3`](orx-dnk3/README.md) | A scene graph based 3d renderer with support for Gltf based assets |
 | [`orx-easing`](orx-easing/README.md) | Provides easing functions for smooth animation or non-linear interpolation. |
 | [`orx-file-watcher`](orx-file-watcher/README.md) | Monitor files on disk and auto-reload them if they change. |
 | [`orx-filter-extension`](orx-filter-extension/README.md) | To apply graphics filters on every animation frame using `extend(FILTER_NAME())`. |
@@ -44,6 +46,7 @@ A growing library of assorted data structures, algorithms and utilities.
 | [`orx-temporal-blur`](orx-temporal-blur/README.md) | Post-processing temporal-blur video effect. CPU intense, therefore not intended  for use with the `ScreenRecorder` extension or other real-time uses. |
 | [`orx-time-operators`](orx-time-operators/README.md) | A collection of time-sensitive functions aimed at controlling raw data over-time,  such as Envelope and LFO. |
 | [`orx-timer`](orx-timer/README.md) | Simple timer functionality providing `repeat`, to run code with a given interval and `timeOut`, to run code once after a given delay. |
+| [`orx-video-profiles`](orx-video-profiles/README.md) | A collection of `VideoWriterProfile` implementations that can be used with `ScreenRecorder` and `VideoWriter` |
 <!-- __orxListEnd__ -->
 
 # Developer notes

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,13 @@ task buildMainReadme {
         for (line in header) {
             newReadme.add(line)
         }
-        newReadme.add("| name" + ("&nbsp;".repeat(36)) + " | description |")
+        newReadme.add("| name" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+          "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + " | description |")
         newReadme.add("| --- | --- |")
 
         // Search for the description at the top of the readme.
@@ -146,7 +152,7 @@ task buildMainReadme {
                 def orxReadmeText = orxReadmeFile.getText()
                 orxReadmeText.find(descriptionRx) {
                     description ->
-                        def trimmedDescription = description[1].strip()
+                        def trimmedDescription = description[1].trim() //.strip() supports unicode, java11 only
                                 .replace("\n", " ").replace("\r", "")
                         newReadme.add("| [`${sub.name}`](${sub.name}/README.md) " +
                                 "| $trimmedDescription |")

--- a/orx-chataigne/README.md
+++ b/orx-chataigne/README.md
@@ -1,7 +1,6 @@
 # orx-chataigne
 
-With `orx-chataigne` you can share [Chataigne](http://benjamin.kuperberg.fr/chataigne/en) variables within a OPENRNDR project. 
-
+Expose variables to [Chataigne](http://benjamin.kuperberg.fr/chataigne/en) and any other applications that can interface with it.
 The current implementation makes use of the OSC protocol and supports `Double` and `ColorRGBa`.
 
 ## Usage


### PR DESCRIPTION
The change to orx-chataigne readme is only to make it look better in the main README.md file.