### PR TITLE
Tweak contour intersection demos

### DIFF
--- a/openrndr-demos/src/demo/kotlin/DemoContourIntersections01.kt
+++ b/openrndr-demos/src/demo/kotlin/DemoContourIntersections01.kt
@@ -29,7 +29,7 @@ fun main() {
                     }
                 }
                 for (i in ints) {
-                    drawer.circle(i.position, 15.0)
+                    drawer.circle(i.position, 10.0)
                 }
             }
         }

--- a/openrndr-demos/src/demo/kotlin/DemoContourIntersections02.kt
+++ b/openrndr-demos/src/demo/kotlin/DemoContourIntersections02.kt
@@ -12,7 +12,6 @@ fun main() {
                 val circle = Circle(mouse.position, 200.0).contour
 
                 drawer.fill = null
-                drawer.stroke = ColorRGBa.GREEN
                 for (y in 50 until height step 100) {
                     for (x in 50 until width step 100) {
 
@@ -21,8 +20,10 @@ fun main() {
 
                             val ints = intersections(circle, r)
                             if (ints.isEmpty()) {
+                                drawer.stroke = ColorRGBa.GREEN
                                 drawer.contour(r)
                             } else {
+                                drawer.stroke = ColorRGBa.WHITE
                                 ints.map { it.contourTB }.let { it + it.take(1) }.zipWithNext().forEach {
                                     val end = if (it.second <= it.first) it.second + 1.0 else it.second
                                     val sub = r.sub(it.first, end)

--- a/openrndr-demos/src/demo/kotlin/DemoContourIntersections03.kt
+++ b/openrndr-demos/src/demo/kotlin/DemoContourIntersections03.kt
@@ -1,5 +1,6 @@
 import org.openrndr.application
 import org.openrndr.color.ColorRGBa
+import org.openrndr.draw.LineJoin
 import org.openrndr.math.Vector2
 import org.openrndr.shape.ShapeContour
 import org.openrndr.shape.intersections
@@ -9,22 +10,25 @@ import kotlin.math.sin
 
 fun main() = application {
     program {
-        val contour = ShapeContour.fromPoints(
-                List(80) {
-                    val a = PI * 2 * it / 80.0
-                    val x = 200.0 * sin(a * 2)
-                    val y = 200.0 * cos(a)
-                    Vector2(x, y)
-                }, closed = true
-        )
-        val ints = intersections(contour, contour)
+        val points = 200
         extend {
+            val contour = ShapeContour.fromPoints(
+                    List(points) {
+                        val a = PI * 2 * it / points
+                        val x = (200 + 50 * cos(a * 2)) * sin(a * 3 + sin(a))
+                        val y = 150 * cos(a * 2 + seconds * 0.2)
+                        Vector2(x, y)
+                    }, closed = true
+            )
+            val ints = intersections(contour, contour)
             drawer.run {
                 clear(ColorRGBa.WHITE)
                 translate(width * 0.5, height * 0.5)
                 fill = null
                 stroke = ColorRGBa.BLACK
+                lineJoin = LineJoin.ROUND
                 contour(contour)
+                fill = ColorRGBa.PINK.opacify(0.3)
                 circles(ints.map { it.position }, 10.0)
             }
         }


### PR DESCRIPTION
1. Change size of circles indicating intersections
to make it obvious that the circles are not filled,
and that only part of the intersecting shapes are
being drawn.

2. Make intersecting shapes more visible by using
different colors. More fun interaction.

3. Animate self-intersecting shape.