### PR TITLE
Add Demo rendering shape strokes with negative dimensions

### DIFF
--- a/openrndr-demos/src/demo/kotlin/DrawerNegativeDimensions.kt
+++ b/openrndr-demos/src/demo/kotlin/DrawerNegativeDimensions.kt
@@ -1,0 +1,42 @@
+// Test negative widths & heights for drawing aligned rectangles.
+// Also draw a circle with negative radius.
+// All shapes should appear with a white 4-pixel border
+
+import org.openrndr.application
+import org.openrndr.color.ColorRGBa
+import org.openrndr.extra.noise.Random
+import org.openrndr.math.Vector2
+import org.openrndr.shape.Rectangle
+
+fun main() = application {
+    program {
+        val margin = 5.0
+        val squareSize = 100.0
+
+        extend {
+            drawer.clear(ColorRGBa.GRAY)
+            drawer.fill = ColorRGBa.PINK
+            drawer.stroke = ColorRGBa.WHITE
+            drawer.strokeWeight = 4.0
+
+            // Top Left
+            drawer.rectangle(margin, margin, squareSize, squareSize)
+            // Top Right
+            drawer.rectangle(width - margin, margin, -squareSize, squareSize)
+            // Bottom Right
+            drawer.rectangle(width - margin, height - margin, -squareSize, -squareSize)
+            // Bottom Left
+            drawer.rectangle(margin, height - margin, squareSize, -squareSize)
+
+            // Circle with negative radius
+            drawer.circle(drawer.bounds.center, -squareSize * 2)
+
+            // Rectangles with the bottom right corner centered in the window
+            drawer.rectangles(List(10) {
+                Rectangle(drawer.bounds.center,
+                        -squareSize * 2 + it * 10,
+                        -squareSize * 2 + it * 10)
+            })
+        }
+    }
+}


### PR DESCRIPTION
The correct rendering of strokes in this demo depends on https://github.com/openrndr/openrndr/pull/154