### PR TITLE
Add vflip argument to GIFProfile

### DIFF
--- a/orx-video-profiles/src/main/kotlin/GIFProfile.kt
+++ b/orx-video-profiles/src/main/kotlin/GIFProfile.kt
@@ -5,6 +5,6 @@ class GIFProfile : VideoWriterProfile() {
     override val fileExtension = "gif"
 
     override fun arguments(): Array<String> {
-        return arrayOf("-vf", "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse=dither=none:diff_mode=rectangle")
+        return arrayOf("-vf", "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse=dither=none:diff_mode=rectangle,vflip")
     }
 }


### PR DESCRIPTION
Fixes the below phenomenon of the y-axis being flipped when using the GIFProfile

![TemplateProgram-2020-12-19-21 36 11](https://user-images.githubusercontent.com/30909373/102699131-d0020480-4242-11eb-8587-0ee63b1b4a58.gif)
