### PR TITLE
Fix ColorChannel in Chataigne

### DIFF
--- a/orx-chataigne/src/main/kotlin/ChataigneOSC.kt
+++ b/orx-chataigne/src/main/kotlin/ChataigneOSC.kt
@@ -29,8 +29,12 @@ open class ChataigneOSC(
 
         init {
             osc.listen(key) {
-                val c = it[0] as Color
-                currentColor = ColorRGBa(c.red / 255.0, c.green / 255.0, c.blue / 255.0, c.alpha / 255.0)
+                val red = it[0] as Float
+                val green = it[1] as Float
+                val blue = it[2] as Float
+                val alpha = it[3] as Float
+
+                currentColor = ColorRGBa(red.toDouble(), green.toDouble(), blue.toDouble(), alpha.toDouble())
             }
         }
 


### PR DESCRIPTION
The casting of the OSC array to a color fails.
Taking a look at `it` with the debugger reveals

<img width="488" alt="grafik" src="https://user-images.githubusercontent.com/8267062/103447937-5df1dc80-4c92-11eb-8038-6a5b674f658b.png">

Its my first time writing Kotlin and its not pretty code for sure but it fixes the bug - I am glad about any code review here!