### PR TITLE
TemporalBlur: allow 0 jitter and fix small bug

### DIFF
--- a/orx-temporal-blur/src/main/kotlin/TemporalBlur.kt
+++ b/orx-temporal-blur/src/main/kotlin/TemporalBlur.kt
@@ -172,8 +172,10 @@ class TemporalBlur : Extension {
             drawer.drawStyle.blendMode = BlendMode.OVER
             drawer.drawStyle.colorMatrix = Matrix55.IDENTITY
             drawer.isolated {
-                val offset = Vector2.uniformRing(0.0, jitter)
-                drawer.projection = Matrix44.translate(offset.x * (1.0 / program.width), offset.y * (1.0 / program.height), 0.0) * drawer.projection
+                if (jitter > 0.0){
+                    val offset = Vector2.uniformRing(0.0, jitter)
+                    drawer.projection = Matrix44.translate(offset.x * (1.0 / program.width), offset.y * (1.0 / program.height), 0.0) * drawer.projection
+                }
 
                 for (extension in extensionTail) {
                     extension.beforeDraw(drawer, program)
@@ -194,6 +196,7 @@ class TemporalBlur : Extension {
 
             add.apply(arrayOf(imageResolved!!.colorBuffer(0), accumulator!!.colorBuffer(0)), accumulator!!.colorBuffer(0))
             program.clock = oldClock
+            fsf.setDouble(program, program.clock())
         }
         image?.let {
             drawer.withTarget(it) {


### PR DESCRIPTION
Setting `jitter` to 0 didn't work before because `Vector2.uniformRing` then tries to generate a number with squared norm strictly less than 0, and gets struck in an infinite loop.

Another small issue I found was that  `samples - 1` different timestamps were used and one was rendered twice. For illustration:

Before:
![frame-04](https://user-images.githubusercontent.com/30909373/106365139-d3090e00-6333-11eb-836f-741e39d23667.png)
After:
![frame-04](https://user-images.githubusercontent.com/30909373/106365142-da301c00-6333-11eb-9105-51fe675e4125.png)
