### PR TITLE
Fix 0x0 render target creation in compositor

### DIFF
--- a/orx-compositor/src/commonMain/kotlin/Compositor.kt
+++ b/orx-compositor/src/commonMain/kotlin/Compositor.kt
@@ -177,7 +177,7 @@ open class Layer internal constructor() {
     }
 
     private fun shouldCreateLayerTarget(activeRenderTarget: RenderTarget): Boolean {
-        return layerTarget == null || (layerTarget?.width != activeRenderTarget.width || layerTarget?.height != activeRenderTarget.height)
+        return layerTarget == null || ((layerTarget?.width != activeRenderTarget.width || layerTarget?.height != activeRenderTarget.height) && activeRenderTarget.width > 0 && activeRenderTarget.height > 0)
     }
 
     private fun createLayerTarget(activeRenderTarget: RenderTarget, drawer: Drawer) {


### PR DESCRIPTION
Similar problem as in orx-panel (https://github.com/openrndr/orx/commit/ba4db38441ee881bd9033ea4dcf33d8112714e50)