### PR TITLE
[orx-git-archiver] Remove trailing whitespace in commit hash

### DIFF
--- a/orx-jvm/orx-git-archiver/src/main/kotlin/NativeGit.kt
+++ b/orx-jvm/orx-git-archiver/src/main/kotlin/NativeGit.kt
@@ -23,7 +23,7 @@ class NativeGit : GitProvider {
     }
 
     override fun headReference(): String {
-        return "git rev-parse --short HEAD".runCommand(dir)!!.first
+        return "git rev-parse --short HEAD".runCommand(dir)!!.first.trimEnd()
     }
 }
 


### PR DESCRIPTION
Small fix for #193. The commit hash of NativeGit has a newline at the end.. I didn't notice it during testing, but orx-gui can't handle the newline which is how it came to my attention