### PR TITLE
[orx-gui] Persist GUI state and change default save location

### DIFF
--- a/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
+++ b/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
@@ -10,7 +10,6 @@ import org.openrndr.dialogs.openFileDialog
 import org.openrndr.dialogs.saveFileDialog
 import org.openrndr.dialogs.setDefaultPathForContext
 import org.openrndr.draw.Drawer
-import org.openrndr.exceptions.stackRootClassName
 import org.openrndr.extra.parameters.*
 import org.openrndr.internal.Driver
 import org.openrndr.math.Vector2
@@ -21,7 +20,6 @@ import org.openrndr.panel.controlManager
 import org.openrndr.panel.elements.*
 import org.openrndr.panel.style.*
 import java.io.File
-import java.nio.file.Paths
 import kotlin.math.roundToInt
 import kotlin.reflect.KMutableProperty1
 
@@ -119,9 +117,19 @@ class GUI : Extension {
 
         program.produceAssets.listen {
             if (listenToProduceAssetsEvent) {
+                val folderFile = File(defaultSaveFolder)
                 val targetFile = File(defaultSaveFolder, "${it.assetMetadata.assetBaseName}.json")
-                logger.info("Saving parameters to '${targetFile.absolutePath}")
-                saveParameters(targetFile)
+                if (folderFile.exists() && folderFile.isDirectory) {
+                    logger.info("Saving parameters to '${targetFile.absolutePath}")
+                    saveParameters(targetFile)
+                } else {
+                    if (folderFile.mkdirs()) {
+                        logger.info("Saving parameters to '${targetFile.absolutePath}")
+                        saveParameters(targetFile)
+                    } else {
+                        logger.error { "Could not save parameters because could not create directory ${folderFile.absolutePath}" }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Addresses issue #38. 

Changes:
1. Default save location using the file dialog is now `gui-parameters` instead of `data/parameters`, and can now be modified using the `defaultSaveFolder` variable. Parameter files created by the `produceAssets` listener are also saved to `defaultSaveFolder`.
2. On termination the GUI parameters are saved to `defaultSaveFolder/latest.json`, and on start they are loaded (if they exist). This can be disabled by setting `persistState = false`; variable `persistState` is `true` by default.

Comments:
1. For me it seems the "Save" button always uses the latest folder I saved in, never the folder in `.file-dialog.properties`. The "Load" button does use the folder in `.file-dialog.properties`. Not sure why this is; I'm on Windows 10.
2. When clicking on the "Load" button, no `.file-dialog.properties` entry is made if it's missing, this only happens when clicking on the "Save" button. I think this should be done on Load too (I can add a commit for this).