### PR TITLE
[orx-gui] Make separate latest.json per program

### DIFF
--- a/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
+++ b/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
@@ -109,7 +109,7 @@ class GUI : Extension {
 
     override fun setup(program: Program) {
         if (persistState) {
-            val guiState = File(defaultSaveFolder, "latest.json")
+            val guiState = File(defaultSaveFolder, "${program.name}-latest.json")
             if (guiState.exists()) {
                 loadParameters(guiState)
             }
@@ -955,10 +955,10 @@ class GUI : Extension {
         if (persistState) {
             val folderFile = File(defaultSaveFolder)
             if (folderFile.exists() && folderFile.isDirectory) {
-                saveParameters(File(defaultSaveFolder, "latest.json"))
+                saveParameters(File(defaultSaveFolder, "${program.name}-latest.json"))
             } else {
                 if (folderFile.mkdirs()) {
-                    saveParameters(File(defaultSaveFolder, "latest.json"))
+                    saveParameters(File(defaultSaveFolder, "${program.name}-latest.json"))
                 } else {
                     logger.error { "Could not persist GUI state because could not create directory ${folderFile.absolutePath}" }
                 }


### PR DESCRIPTION
In PR #197 a latest.json file was added in order to persist the state of the GUI. However, the latest.json file was the same for all programs, therefore when running different programs the state gets overwritten. This PR changes the name of the file to `${program.name}-latest.json` so that every program has its own latest.json file.