### PR TITLE
orx-kinect fix - redundant package name appeared after orx-jvm refact…

### DIFF
--- a/orx-jvm/orx-kinect-common/src/main/kotlin/org/openrndr/extra/kinect/impl/KinectImpl.kt
+++ b/orx-jvm/orx-kinect-common/src/main/kotlin/org/openrndr/extra/kinect/impl/KinectImpl.kt
@@ -1,4 +1,4 @@
-package org.openrndr.extra.kinect.org.openrndr.extra.kinect.impl
+package org.openrndr.extra.kinect.impl
 
 import org.openrndr.Program
 import org.openrndr.draw.*
@@ -10,7 +10,6 @@ import org.openrndr.resourceUrl
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
-import kotlin.concurrent.thread
 
 class DefaultKinects<CTX>(
     private val program: Program,

--- a/orx-jvm/orx-kinect-v1/src/main/kotlin/KinectV1.kt
+++ b/orx-jvm/orx-kinect-v1/src/main/kotlin/KinectV1.kt
@@ -8,7 +8,6 @@ import org.bytedeco.libfreenect.presets.freenect
 import org.openrndr.Program
 import org.openrndr.extra.kinect.*
 import org.openrndr.extra.kinect.impl.*
-import org.openrndr.extra.kinect.org.openrndr.extra.kinect.impl.*
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.*


### PR DESCRIPTION
…oring and broke loading of relative classpath resources Fixes #210