### PR TITLE
Fix PaletteStudio color sorting

### DIFF
--- a/orx-palette/src/main/kotlin/PaletteStudio.kt
+++ b/orx-palette/src/main/kotlin/PaletteStudio.kt
@@ -158,11 +158,15 @@ class PaletteStudio(
     private fun createPalette(colors: List<ColorRGBa>): Palette {
         val sortedColors = when (sortBy) {
             SortBy.DARKEST -> {
-                val darkest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa -> (getLuminance(c1) - getLuminance(c2)).toInt() }
+                val darkest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa ->
+                    ((getLuminance(c1) - getLuminance(c2)) * 1000).toInt()
+                }
                 colors.sortedWith(darkest)
             }
             SortBy.BRIGHTEST -> {
-                val brightest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa -> (getLuminance(c2) - getLuminance(c1)).toInt() }
+                val brightest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa ->
+                    ((getLuminance(c2) - getLuminance(c1)) * 1000).toInt()
+                }
                 colors.sortedWith(brightest)
             }
             SortBy.NO_SORTING -> {

--- a/orx-palette/src/main/kotlin/PaletteStudio.kt
+++ b/orx-palette/src/main/kotlin/PaletteStudio.kt
@@ -157,21 +157,13 @@ class PaletteStudio(
 
     private fun createPalette(colors: List<ColorRGBa>): Palette {
         val sortedColors = when (sortBy) {
-            SortBy.DARKEST -> {
-                val darkest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa ->
-                    ((getLuminance(c1) - getLuminance(c2)) * 1000).toInt()
-                }
-                colors.sortedWith(darkest)
+            SortBy.DARKEST -> colors.sortedBy {
+                getLuminance(it)
             }
-            SortBy.BRIGHTEST -> {
-                val brightest = Comparator<ColorRGBa> { c1: ColorRGBa, c2: ColorRGBa ->
-                    ((getLuminance(c2) - getLuminance(c1)) * 1000).toInt()
-                }
-                colors.sortedWith(brightest)
+            SortBy.BRIGHTEST -> colors.sortedByDescending {
+                getLuminance(it)
             }
-            SortBy.NO_SORTING -> {
-                colors
-            }
+            SortBy.NO_SORTING -> colors
         }
 
         return assemblePalette(sortedColors)


### PR DESCRIPTION
`getLuminance()` returns a normalized Double. 

The comparator used the difference of two normalized luminances and converted the result `.toInt()` which gave `0` in most cases, which did not sort the colors as expected.