### PR TITLE
Add Invert fx filter

### DIFF
--- a/orx-fx/src/commonMain/kotlin/color/Invert.kt
+++ b/orx-fx/src/commonMain/kotlin/color/Invert.kt
@@ -1,0 +1,18 @@
+package org.openrndr.extra.fx.color
+
+import org.openrndr.draw.Filter
+import org.openrndr.extra.fx.fx_invert
+import org.openrndr.extra.fx.fx_sepia
+import org.openrndr.extra.fx.mppFilterShader
+import org.openrndr.extra.parameters.Description
+import org.openrndr.extra.parameters.DoubleParameter
+
+@Description("Invert")
+class Invert : Filter(mppFilterShader(fx_invert, "invert")) {
+    @DoubleParameter("amount", 0.0, 1.0)
+    var amount: Double by parameters
+
+    init {
+        amount = 1.0
+    }
+}

--- a/orx-fx/src/shaders/glsl/color/invert.frag
+++ b/orx-fx/src/shaders/glsl/color/invert.frag
@@ -1,0 +1,12 @@
+in vec2 v_texCoord0;
+uniform sampler2D tex0; // input
+uniform float amount;
+out vec4 o_color;
+
+void main() {
+    vec4 color = texture(tex0, v_texCoord0);
+
+    color.rgb = mix(color.rgb, 1.0 - color.rgb, amount);
+
+    o_color = color;
+}

--- a/orx-fx/src/shaders/glsl/color/invert.frag
+++ b/orx-fx/src/shaders/glsl/color/invert.frag
@@ -6,7 +6,9 @@ out vec4 o_color;
 void main() {
     vec4 color = texture(tex0, v_texCoord0);
 
-    color.rgb = mix(color.rgb, 1.0 - color.rgb, amount);
+    float a = color.a;
+    vec3 rgb = a > 0.0 ? color.rgb / a : vec3(0.0);
+    rgb = mix(rgb, 1.0 - rgb, amount);
 
-    o_color = color;
+    o_color = vec4(rgb * a, a);
 }


### PR DESCRIPTION
To make it convenient to invert a colorBuffer when applying a series of filters.

Invert exists as a filter in CSS.