### PR TITLE
Remove version from jumpflood

### DIFF
--- a/orx-jumpflood/src/demo/kotlin/DemoShapeSDF01.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoShapeSDF01.kt
@@ -4,9 +4,6 @@ import org.openrndr.draw.ColorType
 import org.openrndr.draw.colorBuffer
 import org.openrndr.extensions.SingleScreenshot
 import org.openrndr.extra.jumpfill.ShapeSDF
-import org.openrndr.math.Vector3
-import org.openrndr.math.transforms.transform
-import org.openrndr.shape.Circle
 import org.openrndr.svg.loadSVG
 
 fun main() {
@@ -20,6 +17,8 @@ fun main() {
             val df = colorBuffer(width, height, format = ColorFormat.RGBa, type = ColorType.FLOAT32)
 
             val shapes = loadSVG("orx-jumpflood/src/demo/resources/name.svg").findShapes().map { it.shape }
+            sdf.setShapes(shapes)
+            sdf.apply(emptyArray(), df)
 
             if (System.getProperty("takeScreenshot") == "true") {
                 extend(SingleScreenshot()) {
@@ -27,15 +26,10 @@ fun main() {
                 }
             }
             extend {
-                sdf.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280/2.0, 720.0/2)
-
-                        translate(-1280/2.0, -720.0/2.0)
-                    })
-                })
-                sdf.apply(emptyArray(), df)
-                drawer.image(df)
+                if(mouse.pressedButtons.isEmpty())
+                    drawer.image(df)
+                else
+                    drawer.shapes(shapes)
             }
         }
     }

--- a/orx-jumpflood/src/demo/kotlin/DemoShapeSDF02.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoShapeSDF02.kt
@@ -42,14 +42,9 @@ fun main() {
             extend {
                 drawer.clear(ColorRGBa.PINK)
 
-                sdf0.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
+                sdf0.setShapes(shapes)
 
-                sdf1.setShapes(shapes.mapIndexed { index, it ->
+                sdf1.setShapes(shapes.map {
                     it.transform(transform {
                         translate(1280 / 2.0, 720.0 / 2)
                         rotate(Vector3.Companion.UNIT_Z, seconds * 45.0 - 30.0)

--- a/orx-jumpflood/src/demo/kotlin/DemoShapeSDF03.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoShapeSDF03.kt
@@ -31,6 +31,9 @@ fun main() {
             val shapes = loadSVG("orx-jumpflood/src/demo/resources/name.svg").findShapes().map { it.shape }
             val union = SDFSmoothDifference()
 
+            sdf0.setShapes(shapes)
+            sdf1.setShapes(shapes)
+
             val strokeFill = SDFStrokeFill()
 
             if (System.getProperty("takeScreenshot") == "true") {
@@ -42,19 +45,6 @@ fun main() {
                 drawer.clear(ColorRGBa.PINK)
 
                 fd.apply(emptyArray(), uvmap)
-
-                sdf0.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
-                sdf1.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
 
                 sdf0.useUV = true
                 sdf0.apply(uvmap, df0)

--- a/orx-jumpflood/src/demo/kotlin/DemoShapeSDF04.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoShapeSDF04.kt
@@ -9,7 +9,6 @@ import org.openrndr.extra.gui.GUI
 import org.openrndr.extra.jumpfill.ShapeSDF
 import org.openrndr.extra.jumpfill.draw.SDFStrokeFill
 import org.openrndr.extra.jumpfill.ops.*
-import org.openrndr.math.transforms.transform
 import org.openrndr.shape.Circle
 import org.openrndr.svg.loadSVG
 
@@ -32,8 +31,11 @@ fun main() {
             val uvmap = colorBuffer(width, height, type = ColorType.FLOAT16)
 
             val circleShapes = List(1) { Circle(width/2.0, height/2.0, 200.0).shape}
-
             val shapes = loadSVG("orx-jumpflood/src/demo/resources/name.svg").findShapes().map { it.shape }
+
+            sdf0.setShapes(circleShapes)
+            sdf1.setShapes(shapes)
+
             val difference = SDFSmoothDifference()
             val strokeFill = SDFStrokeFill()
 
@@ -49,19 +51,6 @@ fun main() {
 
                 perturb.phase = seconds * 0.1
                 perturb.apply(uvmap, uvmap)
-
-                sdf0.setShapes(circleShapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
-                sdf1.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
 
                 sdf0.useUV = true
                 sdf0.apply(uvmap, df0)

--- a/orx-jumpflood/src/demo/kotlin/DemoShapeSDF05.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoShapeSDF05.kt
@@ -9,9 +9,7 @@ import org.openrndr.extra.gui.GUI
 import org.openrndr.extra.jumpfill.ShapeSDF
 import org.openrndr.extra.jumpfill.draw.SDFStrokeFill
 import org.openrndr.extra.jumpfill.ops.*
-import org.openrndr.ffmpeg.ScreenRecorder
 import org.openrndr.math.Vector2
-import org.openrndr.math.transforms.transform
 import org.openrndr.shape.Circle
 import org.openrndr.svg.loadSVG
 import kotlin.math.cos
@@ -38,8 +36,11 @@ fun main() {
             val uvmap2 = colorBuffer(width, height, type = ColorType.FLOAT16)
 
             val circleShapes = List(1) { Circle(width/2.0, height/2.0, 200.0).shape}
-
             val shapes = loadSVG("orx-jumpflood/src/demo/resources/name.svg").findShapes().map { it.shape }
+
+            sdf0.setShapes(circleShapes)
+            sdf1.setShapes(shapes)
+
             val difference = SDFSmoothDifference()
             val strokeFill = SDFStrokeFill()
             sdf0.useUV = true
@@ -67,20 +68,6 @@ fun main() {
                 perturb.outputUV = false
                 perturb.phase = seconds * 0.05
                 perturb.apply(uvmap, uvmap2)
-
-                sdf0.setShapes(circleShapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
-                sdf1.setShapes(shapes.mapIndexed { index, it ->
-                    it.transform(transform {
-                        translate(1280 / 2.0, 720.0 / 2)
-                        translate(-1280 / 2.0, -720.0 / 2.0)
-                    })
-                })
-
 
                 sdf0.apply(uvmap2, df0)
                 sdf1.apply(uvmap2, df1)

--- a/orx-jumpflood/src/demo/kotlin/DemoSkeleton01.kt
+++ b/orx-jumpflood/src/demo/kotlin/DemoSkeleton01.kt
@@ -7,7 +7,6 @@ import org.openrndr.draw.isolatedWithTarget
 import org.openrndr.draw.renderTarget
 import org.openrndr.extensions.SingleScreenshot
 import org.openrndr.extra.jumpfill.fx.Skeleton
-import org.openrndr.extra.jumpfill.fx.StraightSkeleton
 import org.openrndr.extra.noise.simplex
 
 fun main() {

--- a/orx-jumpflood/src/main/resources/shaders/gl3/alpha-threshold.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/alpha-threshold.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
 uniform float threshold;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/contour-points.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/contour-points.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/draw/sdf-stroke-fill.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/draw/sdf-stroke-fill.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform float radius;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/encode-points.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/encode-points.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/encode-subpixel.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/encode-subpixel.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
 uniform float threshold;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/inner-bevel.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/inner-bevel.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0; // image
 uniform sampler2D tex1; // distance
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/inner-glow.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/inner-glow.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0; // image
 uniform sampler2D tex1; // distance
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/inpaint.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/inpaint.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// image
 uniform sampler2D tex1;// distance
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/outer-glow.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/outer-glow.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0; // image
 uniform sampler2D tex1; // distance
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/skeleton.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/skeleton.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform vec4 skeletonColor;
 uniform vec4 backgroundColor;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/fx/straight-skeleton.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/fx/straight-skeleton.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform vec4 skeletonColor;
 uniform vec4 backgroundColor;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/jumpflood.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/jumpflood.frag
@@ -1,4 +1,3 @@
-#version 330 core
 in vec2 v_texCoord0;
 
 uniform sampler2D tex0;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-blend.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-blend.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform sampler2D tex1;// signed distance
 uniform float factor;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-onion.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-onion.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform float radius;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-round.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-round.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0; // signed distance
 uniform float radius;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-difference.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-difference.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform sampler2D tex1;// signed distance
 uniform float radius;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-intersection.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-intersection.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;// signed distance
 uniform sampler2D tex1;// signed distance
 uniform float radius;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-union.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/ops/sdf-smooth-union.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0; // signed distance
 uniform sampler2D tex1; // signed distance
 uniform float radius;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/pixel-direction.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/pixel-direction.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 uniform sampler2D tex1;
 uniform vec2 originalSize;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/pixel-distance.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/pixel-distance.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 uniform sampler2D tex1;
 

--- a/orx-jumpflood/src/main/resources/shaders/gl3/shape-sdf.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/shape-sdf.frag
@@ -1,5 +1,3 @@
-#version 330
-
 in vec2 v_texCoord0;
 uniform float iTime;
 out vec4 o_color;

--- a/orx-jumpflood/src/main/resources/shaders/gl3/threshold.frag
+++ b/orx-jumpflood/src/main/resources/shaders/gl3/threshold.frag
@@ -1,5 +1,3 @@
-#version 330 core
-
 uniform sampler2D tex0;
 in vec2 v_texCoord0;
 uniform float threshold;


### PR DESCRIPTION
To make it convenient to invert a colorBuffer when applying a series of filters.

Invert exists as a filter in CSS.