### PR TITLE
Make screenshot generation work again

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Get OPENRNDR
       - name: Get OPENRNDR HEAD ref
@@ -33,15 +33,13 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 17
-      - uses: openrndr/setup-opengl@v1.1
       - name: Test glxinfo
         run: |
-          echo $LD_LIBRARY_PATH
-          export GALLIUM_DRIVER=swr
+          sudo apt install -y mesa-utils xvfb
           xvfb-run glxinfo
 
-#      - name: Collect screenshots
-#        run: xvfb-run ./gradlew collectScreenshots
+      - name: Collect screenshots
+        run: xvfb-run ./gradlew collectScreenshots
       - name: Build main readme
         run: xvfb-run ./gradlew buildMainReadme
       - name: Prepare media branch


### PR DESCRIPTION
This took 3 days to figure out.
It involved creating an Ubuntu 20.04 virtualbox,
compiling and modifying multiple times the latest Mesa,
packaging and uploading it as a tar.gz to openrndr/setup-opengl,
tweaks and debugging suggested by Edwin until discovering that
skipping the openSWR renderer altogether seems
to solve the issue.