### PR TITLE
Hobby curves: add last point for open contours

### DIFF
--- a/orx-shapes/src/commonMain/kotlin/HobbyCurve.kt
+++ b/orx-shapes/src/commonMain/kotlin/HobbyCurve.kt
@@ -11,8 +11,11 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 
-fun ShapeContour.hobbyCurve() : ShapeContour {
-    val vertices = segments.map { it.start }
+fun ShapeContour.hobbyCurve(): ShapeContour {
+    val vertices = if (closed)
+        segments.map { it.start }
+    else
+        segments.map { it.start } + segments.last().end
     return hobbyCurve(vertices, closed)
 }
 


### PR DESCRIPTION
The blue ShapeContour is converted to the red one using `myBlueCurve.hobbyCurve()`

Before this fix the resulting curve ends too early:
![image](https://user-images.githubusercontent.com/108264/154660992-ca170e40-3efe-4352-bd15-7f2ef20abd9b.png)

After the fix the resulting curve shares start and end points with the original curve and passes through all the same control points:
![image](https://user-images.githubusercontent.com/108264/154661050-488d2d4c-8c49-42d5-ba3f-2c4278928e6e.png)
