### PR TITLE
Add contentScale to orx-noclear's renderTarget creation

### DIFF
--- a/orx-no-clear/src/commonMain/kotlin/NoClear.kt
+++ b/orx-no-clear/src/commonMain/kotlin/NoClear.kt
@@ -26,7 +26,7 @@ class NoClear : Extension {
                     it.detachColorAttachments()
                     it.destroy()
                 }
-                renderTarget = renderTarget(program.width, program.height) {
+                renderTarget = renderTarget(program.width, program.height, program.window.contentScale) {
                     colorBuffer()
                     depthBuffer()
                 }


### PR DESCRIPTION
Currently orx-noclear creates somewhat blurry results on hi-dpi screens. I noticed the problem is resolved when contentScale is passed along in the renderTarget.