### PR TITLE
Reduce duplication in orx build scripts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+// root build.gradle
 buildscript {
     repositories {
         mavenCentral()
@@ -12,7 +13,6 @@ plugins {
     // remember to update all the versions here when upgrading kotlin version
     id 'org.jetbrains.kotlin.jvm' apply false
     id 'org.jetbrains.kotlin.multiplatform'  apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.20' apply false
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
@@ -39,43 +39,11 @@ def multiplatformModules = [
 
 def doNotPublish = ["openrndr-demos"]
 
-project.ext {
-    kotlinApiVersion = '1.6'
-    kotlinLanguageVersion = '1.6'
-    kotlinVersion = '1.6.20'
-    kotlinxCoroutinesVersion = '1.6.0'
-    kotlinLoggingVersion = '2.1.21'
-    kotlinxSerializationVersion = '1.3.2'
-    spekVersion = '2.0.15'
-    kluentVersion = '1.68'
-    jsoupVersion = '1.14.3'
-    kotestVersion = '5.2.1'
-    junitJupiterVersion = '5.8.2'
-    slf4jVersion = '1.7.36'
-}
-
-
-
-
 apply plugin: 'org.jetbrains.dokka'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 def openrndrUseSnapshot = isReleaseVersion
-
-project.ext {
-    openrndrVersion = ((findProperty("OPENRNDR.version")?:System.getenv("OPENRNDR_VERSION")) ?.replace("v","")) ?: "0.5.1-SNAPSHOT"
-    jvmTarget = "1.8"
-    kotlinVersion = "1.6.20"
-    kotlinApiVersion = "1.6"
-    spekVersion = "2.0.15"
-    libfreenectVersion = "0.5.7-1.5.7"
-    librealsense2Version = "2.50.0-1.5.7"
-    gsonVersion = "2.9.0"
-    antlrVersion = "4.9.3"
-    tensorflowVersion = "0.4.0"
-    mklDnnVersion = "0.21.5-1.5.7"
-}
 
 allprojects {
     group 'org.openrndr.extra'
@@ -89,18 +57,6 @@ allprojects {
         }
     }
 
-}
-
-switch (org.gradle.internal.os.OperatingSystem.current()) {
-    case org.gradle.internal.os.OperatingSystem.WINDOWS:
-        project.ext.openrndrOS = "windows"
-        break
-    case org.gradle.internal.os.OperatingSystem.LINUX:
-        project.ext.openrndrOS = "linux-x64"
-        break
-    case org.gradle.internal.os.OperatingSystem.MAC_OS:
-        project.ext.openrndrOS = "macos"
-        break
 }
 
 dokka {
@@ -192,6 +148,7 @@ task buildMainReadme {
     }
 }
 
+// publishable && multiplatform
 configure(allprojects.findAll { !doNotPublish.contains(it.name) && (multiplatformModules.contains(it.name)) }) {
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
@@ -258,6 +215,7 @@ configure(allprojects.findAll { !doNotPublish.contains(it.name) && (multiplatfor
 
 }
 
+// publishable && JVM only
 configure(allprojects.findAll { !doNotPublish.contains(it.name) && !multiplatformModules.contains(it.name) }) {
 //    apply plugin: 'idea'
     apply plugin: 'java'
@@ -328,18 +286,16 @@ configure(allprojects.findAll { !doNotPublish.contains(it.name) && !multiplatfor
     }
 
     dependencies {
-        implementation 'io.github.microutils:kotlin-logging:2.1.10'
-        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
-
-        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-        implementation "org.openrndr:openrndr-application:$openrndrVersion"
-        implementation "org.openrndr:openrndr-math:$openrndrVersion"
-
-        testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spekVersion"
-        testImplementation "org.amshove.kluent:kluent:$kluentVersion"
-        testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-        testRuntimeOnly "org.spekframework.spek2:spek-runner-junit5:$spekVersion"
-        testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+        implementation libs.kotlin.logging
+        implementation libs.kotlin.coroutines
+        implementation libs.kotlin.stdlib
+        implementation libs.openrndr.application
+        implementation libs.openrndr.math
+        testImplementation libs.spek.dsl
+        testImplementation libs.kluent
+        testImplementation libs.kotlin.test
+        testRuntimeOnly libs.spek.junit5
+        testRuntimeOnly libs.kotlin.reflect
     }
 
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     `kotlin-dsl`
 }
@@ -9,9 +8,7 @@ sourceSets {
             srcDir("src/preload/kotlin")
         }
     }
-    val main by getting {
-    }
-
+    val main by getting
 }
 
 repositories {
@@ -20,12 +17,14 @@ repositories {
     gradlePluginPortal()
 }
 
-
-val openrndrVersion = ((findProperty("OPENRNDR.version")?.toString())?:System.getenv("OPENRNDR_VERSION"))?.replace("v", "")  ?: "0.5.1-SNAPSHOT"
+val openrndrVersion =
+    (findProperty("OPENRNDR.version")?.toString() ?: System.getenv("OPENRNDR_VERSION"))?.replace("v", "")
+        ?: "0.5.1-SNAPSHOT"
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20")
-    val preloadImplementation by configurations.getting {  }
+    implementation("org.jetbrains.kotlin:kotlin-serialization:1.6.20")
+    val preloadImplementation by configurations.getting
     preloadImplementation("org.openrndr:openrndr-application:$openrndrVersion")
     preloadImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
 }

--- a/openrndr-demos/build.gradle
+++ b/openrndr-demos/build.gradle
@@ -17,14 +17,15 @@ dependencies {
     demoImplementation(project(":orx-noise"))
     demoImplementation(project(":orx-jvm:orx-gui"))
     demoImplementation(project(":orx-shader-phrases"))
-    demoImplementation("org.slf4j:slf4j-simple:1.7.30")
+    demoImplementation(libs.slf4j.simple)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoImplementation(libs.openrndr.svg)
 
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-svg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-ffmpeg-natives-$openrndrOS:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(libs.openrndr.ffmpeg.natives)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-camera/build.gradle.kts
+++ b/orx-camera/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -25,18 +13,20 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
+
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -53,21 +43,23 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -77,11 +69,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-color/build.gradle.kts
+++ b/orx-color/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -29,19 +17,18 @@ kotlin {
                     implementation(project(":orx-mesh-generators"))
                     implementation(project(":orx-color"))
                     implementation(project(":orx-jvm:orx-gui"))
-
-                    implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                    implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                    runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                    runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                    implementation(libs.openrndr.application)
+                    implementation(libs.openrndr.extensions)
+                    runtimeOnly(libs.openrndr.gl3)
+                    runtimeOnly(libs.openrndr.gl3.natives)
                     implementation(compilations["main"]!!.output.allOutputs)
                 }
                 collectScreenshots { }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -58,12 +45,12 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
 
@@ -72,13 +59,12 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
-        val jvmMain by getting {}
-
+        val jvmMain by getting
 
         @Suppress("UNUSED_VARIABLE")
         val jvmTest by getting {
@@ -86,11 +72,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-compositor/build.gradle.kts
+++ b/orx-compositor/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -26,10 +14,10 @@ kotlin {
                     dependencies {
                         implementation(project(":orx-fx"))
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
@@ -38,8 +26,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -57,21 +45,24 @@ kotlin {
                 implementation(project(":orx-fx"))
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -81,11 +72,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-compositor/src/commonMain/kotlin/Compositor.kt
+++ b/orx-compositor/src/commonMain/kotlin/Compositor.kt
@@ -23,6 +23,7 @@ fun RenderTarget.deepDestroy() {
             is CubemapAttachment -> it.cubemap.destroy()
             is ArrayTextureAttachment -> it.arrayTexture.destroy()
             is ArrayCubemapAttachment -> it.arrayCubemap.destroy()
+            else -> {}
         }
     }
     dbcopy?.destroy()

--- a/orx-compute-graph-nodes/build.gradle.kts
+++ b/orx-compute-graph-nodes/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -25,18 +13,19 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -55,21 +44,22 @@ kotlin {
                 implementation(project(":orx-shader-phrases"))
                 implementation(project(":orx-compute-graph"))
                 implementation(project(":orx-image-fit"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -79,11 +69,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-compute-graph/build.gradle.kts
+++ b/orx-compute-graph/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotlinxCoroutinesVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -26,18 +13,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -52,18 +39,20 @@ kotlin {
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
-                api("org.openrndr:openrndr-event:$openrndrVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                api(libs.openrndr.event)
+                implementation(libs.kotlin.coroutines)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -73,11 +62,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-compute-graph/src/commonMain/kotlin/ComputeGraph.kt
+++ b/orx-compute-graph/src/commonMain/kotlin/ComputeGraph.kt
@@ -84,6 +84,7 @@ class ComputeGraph {
      *
      * Eventually we likely want to separate compute-graph definitions from the compute-graph processor.
      */
+    @OptIn(DelicateCoroutinesApi::class)
     fun dispatch(context: CoroutineDispatcher, delayBeforeCompute: Long = 500) {
         var firstRodeo = true
         GlobalScope.launch(context, CoroutineStart.DEFAULT) {

--- a/orx-easing/build.gradle.kts
+++ b/orx-easing/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -26,10 +14,10 @@ kotlin {
                     dependencies {
                         implementation(project(":orx-camera"))
                         implementation(project(":orx-shapes"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
@@ -38,8 +26,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -55,21 +43,22 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":orx-parameters"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -79,11 +68,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-fx/build.gradle.kts
+++ b/orx-fx/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 val embedShaders = tasks.register<EmbedShadersTask>("embedShaders") {
     inputDir.set(file("$projectDir/src/shaders/glsl"))
     outputDir.set(file("$buildDir/generated/shaderKotlin"))
@@ -35,10 +23,10 @@ kotlin {
                     dependencies {
                         implementation(project(":orx-color"))
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
@@ -47,8 +35,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -63,18 +51,19 @@ kotlin {
         val shaderKotlin by creating {
             this.kotlin.srcDir(embedShaders.outputDir)
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
                 implementation(project(":orx-color"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
                 api(shaderKotlin.kotlin)
             }
         }
@@ -84,10 +73,11 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting
 
@@ -97,11 +87,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-glslify/build.gradle
+++ b/orx-glslify/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "com.google.code.gson:gson:$gsonVersion"
+    implementation libs.gson
     implementation "org.rauschig:jarchivelib:1.0.0"
     implementation project(":orx-noise")
 }

--- a/orx-gradient-descent/build.gradle.kts
+++ b/orx-gradient-descent/build.gradle.kts
@@ -3,18 +3,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -23,18 +11,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -51,21 +39,22 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -75,11 +64,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-hash-grid/build.gradle.kts
+++ b/orx-hash-grid/build.gradle.kts
@@ -3,18 +3,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -23,18 +11,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -51,21 +39,22 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -75,11 +64,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-image-fit/build.gradle.kts
+++ b/orx-image-fit/build.gradle.kts
@@ -3,18 +3,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -23,18 +11,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -51,21 +39,22 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -75,11 +64,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-jumpflood/build.gradle
+++ b/orx-jumpflood/build.gradle
@@ -14,11 +14,13 @@ dependencies {
     demoImplementation project(":orx-noise")
     demoImplementation project(":orx-jvm:orx-gui")
     demoImplementation project(":orx-compositor")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-svg:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.svg)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-boofcv/build.gradle.kts
+++ b/orx-jvm/orx-boofcv/build.gradle.kts
@@ -12,18 +12,14 @@ sourceSets {
     collectScreenshots(project, demo) { }
 }
 
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val boofcvVersion = "0.39"
-
 val demoImplementation by configurations.getting {}
 val demoRuntimeOnly by configurations.getting {}
 
 dependencies {
-    api("org.boofcv:boofcv-core:$boofcvVersion")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    api(libs.boofcv)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-chataigne/build.gradle
+++ b/orx-jvm/orx-chataigne/build.gradle
@@ -10,14 +10,15 @@ sourceSets {
 dependencies {
     api project(":orx-jvm:orx-osc")
 
-    implementation "com.google.code.gson:gson:$gsonVersion"
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
+    implementation libs.gson
+    demoImplementation(libs.openrndr.application)
 
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-ffmpeg-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+    demoRuntimeOnly(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoRuntimeOnly(libs.openrndr.ffmpeg.natives)
+
     demoImplementation(project(":orx-fx"))
 //    demoImplementation(project(":orx-osc"))
 

--- a/orx-jvm/orx-dnk3/build.gradle
+++ b/orx-jvm/orx-dnk3/build.gradle
@@ -9,7 +9,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation "com.google.code.gson:gson:$gsonVersion"
+    implementation libs.gson
     implementation(project(":orx-fx"))
     implementation(project(":orx-jvm:orx-keyframer"))
     implementation(project(":orx-easing"))
@@ -20,11 +20,11 @@ dependencies {
     demoImplementation(project(":orx-mesh-generators"))
     demoImplementation(project(":orx-noise"))
 
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-filter:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoImplementation(libs.openrndr.filter)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-dnk3/src/main/kotlin/PBRMaterial.kt
+++ b/orx-jvm/orx-dnk3/src/main/kotlin/PBRMaterial.kt
@@ -598,6 +598,7 @@ class PBRMaterial : Material {
                             shadeStyle.parameter("textureNoise", noise128)
                         }
                     }
+                    else -> {}
                 }
                 when (val source = texture.source) {
                     is Triplanar -> {
@@ -605,6 +606,7 @@ class PBRMaterial : Material {
                         shadeStyle.parameter("textureTriplanarScale$index", source.scale)
                         shadeStyle.parameter("textureTriplanarOffset$index", source.offset)
                     }
+                    else -> {}
                 }
                 if (texture.target is TextureTarget.Height) {
                     val target = texture.target as TextureTarget.Height
@@ -691,6 +693,7 @@ class PBRMaterial : Material {
                 if (texture.target is TextureTarget.Height) {
                     when (val source = texture.source) {
                         is TextureFromColorBuffer -> shadeStyle.parameter("texture$index", source.texture)
+                        else -> {}
                     }
                     when (val source = texture.source) {
                         is Triplanar -> {
@@ -698,6 +701,7 @@ class PBRMaterial : Material {
                             shadeStyle.parameter("textureTriplanarScale$index", source.scale)
                             shadeStyle.parameter("textureTriplanarOffset$index", source.offset)
                         }
+                        else -> {}
                     }
                     val target = texture.target as TextureTarget.Height
                     shadeStyle.parameter("textureHeightScale$index", target.scale)

--- a/orx-jvm/orx-dnk3/src/main/kotlin/SceneRenderer.kt
+++ b/orx-jvm/orx-dnk3/src/main/kotlin/SceneRenderer.kt
@@ -107,6 +107,7 @@ class SceneRenderer {
                         blur.spread = 1.0
                         blur.apply(target.colorBuffer(0), target.colorBuffer(0))
                     }
+                    else -> {}
                 }
             }
         }

--- a/orx-jvm/orx-file-watcher/src/main/kotlin/FileWatcher.kt
+++ b/orx-jvm/orx-file-watcher/src/main/kotlin/FileWatcher.kt
@@ -1,10 +1,7 @@
 package org.operndr.extras.filewatcher
 
 import com.sun.nio.file.SensitivityWatchEventModifier
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import mu.KotlinLogging
 import org.openrndr.Program
 import org.openrndr.launch
@@ -116,6 +113,7 @@ private val watchService by lazy {
     FileSystems.getDefault().newWatchService()
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 private val watchThread by lazy {
     thread(isDaemon = true) {
         while (true) {

--- a/orx-jvm/orx-git-archiver/build.gradle
+++ b/orx-jvm/orx-git-archiver/build.gradle
@@ -15,11 +15,11 @@ dependencies {
     demoImplementation(project(":orx-mesh-generators"))
     demoImplementation(project(":orx-noise"))
 
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-filter:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoImplementation(libs.openrndr.filter)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-gui/build.gradle.kts
+++ b/orx-jvm/orx-gui/build.gradle.kts
@@ -12,26 +12,21 @@ sourceSets {
     collectScreenshots(project, demo) { }
 }
 
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val slf4jVersion: String by rootProject.extra
-val gsonVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
 val demoImplementation by configurations.getting {}
 val demoRuntimeOnly by configurations.getting {}
 
 dependencies {
     api(project(":orx-parameters"))
     api(project(":orx-jvm:orx-panel"))
-    implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-    implementation("org.openrndr:openrndr-dialogs:$openrndrVersion")
-    implementation("com.google.code.gson:gson:$gsonVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
+    implementation(libs.openrndr.filter)
+    implementation(libs.openrndr.dialogs)
+    implementation(libs.gson)
+    implementation(libs.kotlin.reflect)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
 
-    demoRuntimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(libs.slf4j.simple)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-keyframer/build.gradle
+++ b/orx-jvm/orx-keyframer/build.gradle
@@ -31,20 +31,21 @@ generateGrammarSource {
 }
 
 dependencies {
-    antlr("org.antlr:antlr4:$antlrVersion")
-    implementation("org.antlr:antlr4-runtime:$antlrVersion")
+    antlr(libs.antlr)
+    implementation(libs.antlrRuntime)
     implementation(project(":orx-noise"))
     implementation(project(":orx-easing"))
-    implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    implementation libs.gson
+    implementation(libs.kotlin.reflect)
 
     demoImplementation(project(":orx-camera"))
-
     demoImplementation(project(":orx-jvm:orx-panel"))
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+
     demoImplementation(sourceSets.getByName("main").output)
 }
 

--- a/orx-jvm/orx-kinect-v1-demo/build.gradle
+++ b/orx-jvm/orx-kinect-v1-demo/build.gradle
@@ -1,13 +1,7 @@
-def os = org.gradle.internal.os.OperatingSystem.current()
-def openrndrOs
-if      (os.windows) { openrndrOs = "windows" }
-else if (os.macOsX)  { openrndrOs = "macos" }
-else if (os.linux)   { openrndrOs = "linux-x64" }
-
 dependencies {
     implementation project(":orx-jvm:orx-kinect-v1")
-    runtimeOnly project(":orx-jvm:orx-kinect-v1-natives-$openrndrOs")
-    runtimeOnly "org.openrndr:openrndr-gl3:$openrndrVersion"
-    runtimeOnly "org.openrndr:openrndr-gl3-natives-$openrndrOs:$openrndrVersion"
+    runtimeOnly project(":orx-jvm:orx-kinect-v1-natives-${gradle.ext.openrndrOS}")
+    runtimeOnly libs.openrndr.gl3
+    runtimeOnly libs.openrndr.gl3.natives
     runtimeOnly "ch.qos.logback:logback-classic:1.2.11"
 }

--- a/orx-jvm/orx-kinect-v1-natives-linux-arm64/build.gradle
+++ b/orx-jvm/orx-kinect-v1-natives-linux-arm64/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.bytedeco:libfreenect:$libfreenectVersion:linux-arm64"
+    runtimeOnly(variantOf(libs.libfreenect) { classifier("linux-arm64") })
 }

--- a/orx-jvm/orx-kinect-v1-natives-linux-x64/build.gradle
+++ b/orx-jvm/orx-kinect-v1-natives-linux-x64/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.bytedeco:libfreenect:$libfreenectVersion:linux-x86_64"
+    runtimeOnly(variantOf(libs.libfreenect) { classifier("linux-x86_64") })
 }

--- a/orx-jvm/orx-kinect-v1-natives-macos/build.gradle
+++ b/orx-jvm/orx-kinect-v1-natives-macos/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.bytedeco:libfreenect:$libfreenectVersion:macosx-x86_64"
+    runtimeOnly(variantOf(libs.libfreenect) { classifier("macosx-x86_64") })
 }

--- a/orx-jvm/orx-kinect-v1-natives-windows/build.gradle
+++ b/orx-jvm/orx-kinect-v1-natives-windows/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.bytedeco:libfreenect:$libfreenectVersion:windows-x86_64"
+    runtimeOnly(variantOf(libs.libfreenect) { classifier("windows-x86_64") })
 }

--- a/orx-jvm/orx-kinect-v1/build.gradle
+++ b/orx-jvm/orx-kinect-v1/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     api project(":orx-jvm:orx-kinect-common")
-    api "org.bytedeco:libfreenect:$libfreenectVersion"
+    api libs.libfreenect
 }

--- a/orx-jvm/orx-kotlin-parser/build.gradle
+++ b/orx-jvm/orx-kotlin-parser/build.gradle
@@ -31,15 +31,17 @@ generateGrammarSource {
 }
 
 dependencies {
-    antlr("org.antlr:antlr4:$antlrVersion")
-    implementation("org.antlr:antlr4-runtime:$antlrVersion")
+    antlr(libs.antlr)
+    implementation(libs.antlrRuntime)
 
     demoImplementation(project(":orx-camera"))
     demoImplementation(project(":orx-jvm:orx-panel"))
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+
     demoImplementation(sourceSets.getByName("main").output)
 }
 

--- a/orx-jvm/orx-minim/build.gradle.kts
+++ b/orx-jvm/orx-minim/build.gradle.kts
@@ -9,10 +9,6 @@ sourceSets {
     }
 }
 
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val slf4jVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
 val demoImplementation by configurations.getting {}
 val demoRuntimeOnly by configurations.getting {}
 
@@ -23,12 +19,12 @@ dependencies {
     api("net.compartmental.code:minim:2.2.2") {
         exclude(group = "org.apache.maven.plugins", module = "maven-javadoc-plugin")
     }
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
+    implementation(libs.kotlin.reflect)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
 
-    demoRuntimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(libs.slf4j.simple)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-olive/build.gradle
+++ b/orx-jvm/orx-olive/build.gradle
@@ -12,16 +12,17 @@ dependencies {
     implementation project(":orx-jvm:orx-file-watcher")
     implementation project(":orx-jvm:orx-kotlin-parser")
     
-    implementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-jvm-host:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-jsr223:$kotlinVersion"
-
+    implementation libs.kotlin.scriptingJvm
+    implementation libs.kotlin.scriptingJvmHost
+    implementation libs.kotlin.reflect
+    implementation libs.kotlin.scriptingJSR223
 
     demoImplementation(project(":orx-camera"))
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-olive/src/main/kotlin/Olive.kt
+++ b/orx-jvm/orx-olive/src/main/kotlin/Olive.kt
@@ -1,5 +1,6 @@
 package org.openrndr.extra.olive
 
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import mu.KotlinLogging
@@ -67,6 +68,7 @@ class Olive<P : Program>(val resources: Resources? = null, private var scriptMod
 
     private var watcher: (() -> Unit)? = null
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun setup(program: Program) {
         System.setProperty("idea.io.use.fallback", "true")
         System.setProperty("org.openrndr.ignoreShadeStyleErrors", "true")
@@ -74,22 +76,22 @@ class Olive<P : Program>(val resources: Resources? = null, private var scriptMod
         val store = mutableMapOf<Event<*>, List<(Any) -> Unit>>()
         val originalExtensions = program.extensions.map { it }
         val trackedListeners = listOf<Event<*>>(program.mouse.buttonDown,
-                program.mouse.buttonUp,
-                program.mouse.clicked,
-                program.mouse.dragged,
-                program.mouse.moved,
-                program.mouse.scrolled,
-                program.keyboard.keyUp,
-                program.keyboard.keyDown,
-                program.keyboard.keyRepeat,
-                program.window.drop,
-                program.window.focused,
-                program.window.minimized,
-                program.window.moved,
-                program.window.sized,
-                program.window.unfocused,
-                program.requestAssets,
-                program.produceAssets
+            program.mouse.buttonUp,
+            program.mouse.clicked,
+            program.mouse.dragged,
+            program.mouse.moved,
+            program.mouse.scrolled,
+            program.keyboard.keyUp,
+            program.keyboard.keyDown,
+            program.keyboard.keyRepeat,
+            program.window.drop,
+            program.window.focused,
+            program.window.minimized,
+            program.window.moved,
+            program.window.sized,
+            program.window.unfocused,
+            program.requestAssets,
+            program.produceAssets
         )
 
         trackedListeners.forEach { it.saveListeners(store) }

--- a/orx-jvm/orx-panel/build.gradle.kts
+++ b/orx-jvm/orx-panel/build.gradle.kts
@@ -12,21 +12,16 @@ sourceSets {
     collectScreenshots(project, demo) { }
 }
 
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val slf4jVersion:String by rootProject.extra
-val kotlinVersion:String by rootProject.extra
-val gsonVersion:String by rootProject.extra
 val demoImplementation by configurations.getting {}
 
 val demoRuntimeOnly by configurations.getting {}
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-dialogs:$openrndrVersion")
-    demoImplementation("com.google.code.gson:gson:$gsonVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    implementation(libs.kotlin.reflect)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.dialogs)
+    demoImplementation(libs.gson)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/SequenceEditor.kt
+++ b/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/SequenceEditor.kt
@@ -41,6 +41,7 @@ class SequenceEditor : SequenceEditorBase("sequence-editor") {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 open class SequenceEditorBase(type: String = "sequence-editor-base") : Element(ElementType(type)), DisposableElement {
     override var disposed = false
 
@@ -57,8 +58,8 @@ open class SequenceEditorBase(type: String = "sequence-editor-base") : Element(E
     private val footerHeight = 20.0
 
     internal class ValueChangedEvent(val source: SequenceEditorBase,
-                                     val oldValue: List<Double>,
-                                     val newValue: List<Double>)
+        val oldValue: List<Double>,
+        val newValue: List<Double>)
 
     internal class Events {
         val valueChanged = Event<ValueChangedEvent>("sequence-editor-base-value-changed")

--- a/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Slider.kt
+++ b/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Slider.kt
@@ -1,8 +1,6 @@
 package org.openrndr.panel.elements
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.*
 import mu.KotlinLogging
 import org.openrndr.*
 import org.openrndr.draw.Cursor
@@ -291,6 +289,7 @@ class Slider : Element(ElementType("slider")), DisposableElement {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 fun Slider.bind(property: KMutableProperty0<Double>) {
     var currentValue: Double? = null
 
@@ -323,6 +322,7 @@ fun Slider.bind(property: KMutableProperty0<Double>) {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 @JvmName("bindInt")
 fun Slider.bind(property: KMutableProperty0<Int>) {
     var currentValue: Int? = null

--- a/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Textfield.kt
+++ b/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Textfield.kt
@@ -1,13 +1,11 @@
 package org.openrndr.panel.elements
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import org.openrndr.KEY_BACKSPACE
 import org.openrndr.color.ColorRGBa
 import org.openrndr.draw.Drawer
 import org.openrndr.draw.LineCap
 import org.openrndr.panel.style.*
-import kotlinx.coroutines.yield
 import org.openrndr.KeyModifier
 import org.openrndr.draw.Cursor
 import org.openrndr.draw.writer
@@ -138,6 +136,7 @@ class Textfield : Element(ElementType("textfield")), DisposableElement {
     override var disposed: Boolean = false
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 fun Textfield.bind(property: KMutableProperty0<String>) {
     GlobalScope.launch {
         install@ while (!disposed) {

--- a/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Toggle.kt
+++ b/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/elements/Toggle.kt
@@ -1,14 +1,12 @@
 package org.openrndr.panel.elements
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import org.openrndr.draw.Drawer
 import org.openrndr.draw.FontImageMap
 import org.openrndr.draw.LineCap
 import org.openrndr.panel.style.*
 import org.openrndr.shape.Rectangle
 
-import kotlinx.coroutines.yield
 import org.openrndr.draw.Writer
 import org.openrndr.events.Event
 import org.openrndr.launch
@@ -100,6 +98,7 @@ class Toggle : Element(ElementType("toggle")), DisposableElement {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 fun Toggle.bind(property: KMutableProperty0<Boolean>) {
     var currentValue = property.get()
     value = currentValue

--- a/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/style/Matcher.kt
+++ b/orx-jvm/orx-panel/src/main/kotlin/org/openrndr/panel/style/Matcher.kt
@@ -48,7 +48,7 @@ class Matcher {
                 Combinator.LATER_SIBLING -> if (result == MatchingResult.RESTART_FROM_CLOSEST_DESCENDANT) {
                     return result
                 }
-                Combinator.DESCENDANT -> {
+                Combinator.DESCENDANT, null -> {
                     // intentionally do nothing
                 }
             }

--- a/orx-jvm/orx-poisson-fill/build.gradle.kts
+++ b/orx-jvm/orx-poisson-fill/build.gradle.kts
@@ -12,21 +12,17 @@ sourceSets {
     collectScreenshots(project, demo) { }
 }
 
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val slf4jVersion:String by rootProject.extra
-
 val demoImplementation by configurations.getting {}
 val demoRuntimeOnly by configurations.getting {}
 
 dependencies {
     implementation(project(":orx-fx"))
     implementation(project(":orx-noise"))
-    implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    implementation(libs.openrndr.filter)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.slf4j.simple)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-poisson-fill/src/main/kotlin/ConvolutionPyramid.kt
+++ b/orx-jvm/orx-poisson-fill/src/main/kotlin/ConvolutionPyramid.kt
@@ -130,6 +130,7 @@ internal class ConvolutionPyramid(width: Int, height: Int,
                     is CubemapAttachment -> it.cubemap.destroy()
                     is ArrayTextureAttachment -> it.arrayTexture.destroy()
                     is ArrayCubemapAttachment -> it.arrayCubemap.destroy()
+                    else -> {}
                 }
             }
             it.detachColorAttachments()

--- a/orx-jvm/orx-rabbit-control/build.gradle
+++ b/orx-jvm/orx-rabbit-control/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     implementation "com.google.zxing:javase:3.4.0"
     implementation "io.ktor:ktor-server-netty:1.3.1"
 
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-realsense2-natives-linux-x64/build.gradle
+++ b/orx-jvm/orx-realsense2-natives-linux-x64/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.bytedeco:librealsense2:$librealsense2Version:linux-x86_64"
+    runtimeOnly(variantOf(libs.librealsense) { classifier("linux-x86_64") })
 }

--- a/orx-jvm/orx-realsense2-natives-macos/build.gradle
+++ b/orx-jvm/orx-realsense2-natives-macos/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-    runtimeOnly "org.bytedeco:librealsense2:$librealsense2Version:macosx-x86_64"
+    runtimeOnly(variantOf(libs.librealsense) { classifier("macosx-x86_64") })
 }

--- a/orx-jvm/orx-realsense2-natives-windows/build.gradle
+++ b/orx-jvm/orx-realsense2-natives-windows/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-    runtimeOnly "org.bytedeco:librealsense2:$librealsense2Version:windows-x86_64"
+    runtimeOnly(variantOf(libs.librealsense) { classifier("windows-x86_64") })
 }

--- a/orx-jvm/orx-realsense2/build.gradle
+++ b/orx-jvm/orx-realsense2/build.gradle
@@ -11,13 +11,12 @@ sourceSets {
 
 
 dependencies {
-    api "org.bytedeco:librealsense2:$librealsense2Version"
-
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly(project(":orx-jvm:orx-realsense2-natives-$openrndrOS"))
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    api libs.librealsense
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(project(":orx-jvm:orx-realsense2-natives-${gradle.ext.openrndrOS}"))
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 
 }

--- a/orx-jvm/orx-runway/build.gradle
+++ b/orx-jvm/orx-runway/build.gradle
@@ -8,14 +8,16 @@ sourceSets {
     }
 }
 dependencies {
-    implementation "com.google.code.gson:gson:$gsonVersion"
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
+    implementation(libs.gson)
+    demoImplementation(libs.openrndr.application)
 
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-ffmpeg-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+    demoRuntimeOnly(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoRuntimeOnly(libs.openrndr.ffmpeg.natives)
+
     demoImplementation(project(":orx-fx"))
+
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-syphon/build.gradle
+++ b/orx-jvm/orx-syphon/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "org.openrndr:openrndr-application:$openrndrVersion"
-    implementation "org.openrndr:openrndr-gl3:$openrndrVersion"
-    implementation "org.openrndr:openrndr-gl3-natives-macos:$openrndrVersion"
+    implementation libs.openrndr.application
+    implementation libs.openrndr.gl3
+    implementation libs.openrndr.gl3.natives
 }

--- a/orx-jvm/orx-tensorflow-gpu-natives-linux-x64/build.gradle
+++ b/orx-jvm/orx-tensorflow-gpu-natives-linux-x64/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.tensorflow:tensorflow-core-api:$tensorflowVersion:linux-x86_64-gpu"
+    runtimeOnly(variantOf(libs.tensorflow) { classifier("linux-x86_64-gpu") })
 }

--- a/orx-jvm/orx-tensorflow-gpu-natives-windows/build.gradle
+++ b/orx-jvm/orx-tensorflow-gpu-natives-windows/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.tensorflow:tensorflow-core-api:$tensorflowVersion:windows-x86_64-gpu"
+    runtimeOnly(variantOf(libs.tensorflow) { classifier("windows-x86_64-gpu") })
 }

--- a/orx-jvm/orx-tensorflow-natives-linux-x64/build.gradle
+++ b/orx-jvm/orx-tensorflow-natives-linux-x64/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.tensorflow:tensorflow-core-api:$tensorflowVersion:linux-x86_64"
+    runtimeOnly(variantOf(libs.tensorflow) { classifier("linux-x86_64") })
 }

--- a/orx-jvm/orx-tensorflow-natives-macos/build.gradle
+++ b/orx-jvm/orx-tensorflow-natives-macos/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.tensorflow:tensorflow-core-api:$tensorflowVersion:macosx-x86_64"
+    runtimeOnly(variantOf(libs.tensorflow) { classifier("macosx-x86_64") })
 }

--- a/orx-jvm/orx-tensorflow-natives-windows/build.gradle
+++ b/orx-jvm/orx-tensorflow-natives-windows/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly "org.tensorflow:tensorflow-core-api:$tensorflowVersion:windows-x86_64"
+    runtimeOnly(variantOf(libs.tensorflow) { classifier("windows-x86_64") })
 }

--- a/orx-jvm/orx-tensorflow/build.gradle
+++ b/orx-jvm/orx-tensorflow/build.gradle
@@ -32,19 +32,20 @@ compileWrapgenKotlin {
 
 
 dependencies {
-    implementation "com.google.code.gson:gson:$gsonVersion"
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
+    implementation libs.gson
+    demoImplementation(libs.openrndr.application)
 
 
-    demoRuntimeOnly(project(":orx-jvm:orx-tensorflow-natives-$openrndrOS"))
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-ffmpeg-natives-$openrndrOS:$openrndrVersion")
+    demoRuntimeOnly(project(":orx-jvm:orx-tensorflow-natives-${gradle.ext.openrndrOS}"))
+
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+    demoRuntimeOnly(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoRuntimeOnly(libs.openrndr.ffmpeg.natives)
     demoImplementation(project(":orx-fx"))
     demoImplementation(sourceSets.getByName("main").output)
-    api("org.tensorflow:tensorflow-core-api:$tensorflowVersion")
+    api(libs.tensorflow)
 
     // -- wrapgen
     wrapgenImplementation 'com.github.javaparser:javaparser-core:3.15.21'

--- a/orx-jvm/orx-triangulation/build.gradle
+++ b/orx-jvm/orx-triangulation/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 
     implementation("com.github.ricardomatias:delaunator:$delaunatorVersion")
 
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-jvm/orx-video-profiles/build.gradle
+++ b/orx-jvm/orx-video-profiles/build.gradle
@@ -9,11 +9,11 @@ sourceSets {
 }
 
 dependencies {
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
-    implementation("org.openrndr:openrndr-ffmpeg:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoImplementation(libs.openrndr.ffmpeg)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
+    implementation(libs.openrndr.ffmpeg)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-kdtree/build.gradle
+++ b/orx-kdtree/build.gradle
@@ -9,9 +9,9 @@ sourceSets {
 }
 
 dependencies {
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-kdtree/src/main/kotlin/KDTree.kt
+++ b/orx-kdtree/src/main/kotlin/KDTree.kt
@@ -1,9 +1,6 @@
 package org.openrndr.extra.kdtree
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import org.openrndr.math.*
 import java.util.*
 import kotlin.IllegalStateException
@@ -99,6 +96,7 @@ private fun <T> insertItem(root: KDTreeNode<T>, item: T): KDTreeNode<T> {
 }
 
 
+@OptIn(DelicateCoroutinesApi::class)
 fun <T> buildKDTree(items: MutableList<T>, dimensions: Int, mapper: (T, Int) -> Double): KDTreeNode<T> {
     val root = KDTreeNode<T>(dimensions, mapper)
 

--- a/orx-mesh-generators/build.gradle
+++ b/orx-mesh-generators/build.gradle
@@ -10,10 +10,10 @@ sourceSets {
 
 dependencies {
     demoImplementation(project(":orx-camera"))
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
 
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-no-clear/build.gradle.kts
+++ b/orx-no-clear/build.gradle.kts
@@ -3,16 +3,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -21,18 +11,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -49,20 +39,21 @@ kotlin {
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-math:$openrndrVersion")
-                implementation("org.openrndr:openrndr-shape:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.math)
+                implementation(libs.openrndr.shape)
+                implementation(libs.openrndr.draw)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -75,11 +66,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-noise/build.gradle.kts
+++ b/orx-noise/build.gradle.kts
@@ -5,16 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -24,19 +14,19 @@ kotlin {
                     dependencies {
                         implementation(project(":orx-camera"))
                         implementation(project(":orx-hash-grid"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
-                collectScreenshots {  }
+                collectScreenshots { }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -53,21 +43,23 @@ kotlin {
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-math:$openrndrVersion")
-                implementation("org.openrndr:openrndr-shape:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.math)
+                implementation(libs.openrndr.shape)
+                implementation(libs.openrndr.draw)
+
                 implementation(project(":orx-hash-grid"))
 
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -80,11 +72,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-palette/build.gradle
+++ b/orx-palette/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "com.google.code.gson:gson:$gsonVersion"
+    implementation libs.gson
     implementation project(":orx-noise")
 }
 

--- a/orx-parameters/build.gradle.kts
+++ b/orx-parameters/build.gradle.kts
@@ -3,23 +3,11 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -34,24 +22,27 @@ kotlin {
         val shaderKotlin by creating {
             this.kotlin.srcDir("$projectDir/build/generated/shaderKotlin")
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-math:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.math)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting
 
@@ -61,11 +52,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-quadtree/build.gradle.kts
+++ b/orx-quadtree/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -26,10 +14,10 @@ kotlin {
                     dependencies {
                         implementation(project(":orx-camera"))
                         implementation(project(":orx-noise"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
@@ -39,8 +27,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -57,21 +45,22 @@ kotlin {
             dependencies {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -81,11 +70,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-shade-styles/build.gradle.kts
+++ b/orx-shade-styles/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -25,10 +13,10 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-color"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                     collectScreenshots { }
@@ -36,8 +24,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -55,12 +43,12 @@ kotlin {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
                 implementation(project(":orx-color"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
 
@@ -69,8 +57,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -80,11 +68,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-shader-phrases/build.gradle.kts
+++ b/orx-shader-phrases/build.gradle.kts
@@ -3,18 +3,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 val embedShaders = tasks.register<EmbedShadersTask>("embedShaders") {
     inputDir.set(file("$projectDir/src/shaders/glsl"))
     outputDir.set(file("$buildDir/generated/shaderKotlin"))
@@ -29,18 +17,18 @@ kotlin {
                     kotlin.srcDir("src/demo")
                     dependencies {
                         implementation(project(":orx-camera"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -55,14 +43,15 @@ kotlin {
         val shaderKotlin by creating {
             this.kotlin.srcDir(embedShaders.outputDir)
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
                 api(shaderKotlin.kotlin)
             }
         }
@@ -72,10 +61,11 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting
 
@@ -85,12 +75,11 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                runtimeOnly(libs.slf4j.simple)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-shapes/build.gradle.kts
+++ b/orx-shapes/build.gradle.kts
@@ -5,18 +5,6 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxSerializationVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
-val junitJupiterVersion: String by rootProject.extra
-val jvmTarget: String by rootProject.extra
-val kotlinApiVersion: String by rootProject.extra
-val kotlinVersion: String by rootProject.extra
-val kotlinLoggingVersion: String by rootProject.extra
-val kluentVersion: String by rootProject.extra
-val openrndrVersion: String by rootProject.extra
-val openrndrOS: String by rootProject.extra
-val spekVersion: String by rootProject.extra
-
 kotlin {
     jvm {
         compilations {
@@ -27,10 +15,10 @@ kotlin {
                         implementation(project(":orx-camera"))
                         implementation(project(":orx-color"))
                         implementation(project(":orx-jvm:orx-triangulation"))
-                        implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                        implementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-                        runtimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+                        implementation(libs.openrndr.application)
+                        implementation(libs.openrndr.extensions)
+                        runtimeOnly(libs.openrndr.gl3)
+                        runtimeOnly(libs.openrndr.gl3.natives)
                         implementation(compilations["main"]!!.output.allOutputs)
                     }
                 }
@@ -40,8 +28,8 @@ kotlin {
             }
         }
         compilations.all {
-            kotlinOptions.jvmTarget = jvmTarget
-            kotlinOptions.apiVersion = kotlinApiVersion
+            kotlinOptions.jvmTarget = libs.versions.jvmTarget.get()
+            kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -59,27 +47,29 @@ kotlin {
                 implementation(project(":orx-parameters"))
                 implementation(project(":orx-shader-phrases"))
                 implementation(project(":orx-color"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
-                implementation("org.openrndr:openrndr-application:$openrndrVersion")
-                implementation("org.openrndr:openrndr-draw:$openrndrVersion")
-                implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-                implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-                implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+                implementation(libs.kotlin.serialization.core)
+                implementation(libs.openrndr.application)
+                implementation(libs.openrndr.draw)
+                implementation(libs.openrndr.filter)
+                implementation(libs.kotlin.reflect)
+                implementation(libs.kotlin.logging)
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting {
             dependencies {
                 implementation(project(":orx-jvm:orx-triangulation"))
             }
         }
+
         @Suppress("UNUSED_VARIABLE")
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation(libs.kotlin.serialization.json)
+                implementation(libs.kotest)
             }
         }
 
@@ -89,11 +79,10 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-                runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-                implementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-                implementation("org.amshove.kluent:kluent:$kluentVersion")
+                implementation(libs.kotlin.serialization.json)
+                runtimeOnly(libs.bundles.jupiter)
+                implementation(libs.spek.dsl)
+                implementation(libs.kluent)
             }
         }
 

--- a/orx-temporal-blur/build.gradle
+++ b/orx-temporal-blur/build.gradle
@@ -11,10 +11,10 @@ sourceSets {
 dependencies {
     implementation project(":orx-noise")
     implementation project(":orx-fx")
-    implementation("org.openrndr:openrndr-filter:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    implementation(libs.openrndr.filter)
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-time-operators/build.gradle
+++ b/orx-time-operators/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     implementation project(":orx-parameters")
 
     demoImplementation(project(":orx-camera"))
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/orx-timer/build.gradle
+++ b/orx-timer/build.gradle
@@ -9,9 +9,9 @@ sourceSets {
 }
 
 dependencies {
-    demoImplementation("org.openrndr:openrndr-application:$openrndrVersion")
-    demoImplementation("org.openrndr:openrndr-extensions:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3:$openrndrVersion")
-    demoRuntimeOnly("org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion")
+    demoImplementation(libs.openrndr.application)
+    demoImplementation(libs.openrndr.extensions)
+    demoRuntimeOnly(libs.openrndr.gl3)
+    demoRuntimeOnly(libs.openrndr.gl3.natives)
     demoImplementation(sourceSets.getByName("main").output)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,89 @@
 rootProject.name = 'orx'
 
+switch (org.gradle.internal.os.OperatingSystem.current()) {
+    case org.gradle.internal.os.OperatingSystem.WINDOWS:
+        gradle.ext.openrndrOS = "windows"
+        break
+    case org.gradle.internal.os.OperatingSystem.LINUX:
+        gradle.ext.openrndrOS = "linux-x64"
+        break
+    case org.gradle.internal.os.OperatingSystem.MAC_OS:
+        gradle.ext.openrndrOS = "macos"
+        break
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            version('kotlinApi', '1.6')
+            version('kotlinLanguage', '1.6')
+            version('kotlin', '1.6.20')
+            version('jvmTarget', '1.8')
+            version('kotlinxCoroutines', '1.6.0')
+            version('kotlinLogging', '2.1.21')
+            version('kotlinxSerialization', '1.3.2')
+            version('spek', '2.0.15')
+            version('boofcv', '0.39')
+            version('kluent', '1.68')
+            version('kotest', '5.2.1')
+            version('junitJupiter', '5.8.2')
+            version('slf4j', '1.7.36')
+            version('openrndr', ((rootProject.properties.getOrDefault('OPENRNDR.version', System.getenv("OPENRNDR_VERSION"))) ?.replace('v','')) ?: '0.5.1-SNAPSHOT')
+            version('libfreenect', '0.5.7-1.5.7')
+            version('librealsense', '2.50.0-1.5.7')
+            version('gson', '2.9.0')
+            version('antlr', '4.9.3')
+            version('tensorflow', '0.4.0')
+
+            library('openrndr-application', 'org.openrndr', 'openrndr-application').versionRef('openrndr')
+            library('openrndr-extensions', 'org.openrndr', 'openrndr-extensions').versionRef('openrndr')
+            library('openrndr-math', 'org.openrndr', 'openrndr-math').versionRef('openrndr')
+            library('openrndr-shape', 'org.openrndr', 'openrndr-shape').versionRef('openrndr')
+            library('openrndr-draw', 'org.openrndr', 'openrndr-draw').versionRef('openrndr')
+            library('openrndr-event', 'org.openrndr', 'openrndr-event').versionRef('openrndr')
+            library('openrndr-filter', 'org.openrndr', 'openrndr-filter').versionRef('openrndr')
+            library('openrndr-dialogs', 'org.openrndr', 'openrndr-dialogs').versionRef('openrndr')
+            library('openrndr-ffmpeg', 'org.openrndr', 'openrndr-ffmpeg').versionRef('openrndr')
+            library('openrndr-ffmpeg-natives', 'org.openrndr', "openrndr-ffmpeg-natives-${gradle.ext.openrndrOS}").versionRef('openrndr')
+            library('openrndr-svg', 'org.openrndr', 'openrndr-svg').versionRef('openrndr')
+            library('openrndr-gl3', 'org.openrndr', 'openrndr-gl3').versionRef('openrndr')
+            library('openrndr-gl3-natives', 'org.openrndr', "openrndr-gl3-natives-${gradle.ext.openrndrOS}").versionRef('openrndr')
+
+            library('tensorflow', 'org.tensorflow' ,'tensorflow-core-api').versionRef('tensorflow')
+            library('boofcv', 'org.boofcv' ,'boofcv-core').versionRef('boofcv')
+            library('libfreenect', 'org.bytedeco' ,'libfreenect').versionRef('libfreenect')
+            library('librealsense', 'org.bytedeco' ,'librealsense2').versionRef('librealsense')
+
+            library('kotlin-logging', 'io.github.microutils' ,'kotlin-logging').versionRef('kotlinLogging')
+            library('kotlin-coroutines', 'org.jetbrains.kotlinx', 'kotlinx-coroutines-core').versionRef('kotlinxCoroutines')
+            library('kotlin-serialization-json', 'org.jetbrains.kotlinx', 'kotlinx-serialization-json').versionRef('kotlinxSerialization')
+            library('kotlin-serialization-core', 'org.jetbrains.kotlinx', 'kotlinx-serialization-core').versionRef('kotlinxSerialization')
+            library('kotlin-stdlib', 'org.jetbrains.kotlin', 'kotlin-stdlib').versionRef('kotlin')
+            library('kotlin-test', 'org.jetbrains.kotlin', 'kotlin-test').versionRef('kotlin')
+            library('kotlin-reflect', 'org.jetbrains.kotlin', 'kotlin-reflect').versionRef('kotlin')
+            library('kotlin-gradlePlugin', 'org.jetbrains.kotlin', 'kotlin-gradle-plugin').versionRef('kotlin')
+            library('kotlin-scriptingJvm', 'org.jetbrains.kotlin', 'kotlin-scripting-jvm').versionRef('kotlin')
+            library('kotlin-scriptingJvmHost', 'org.jetbrains.kotlin', 'kotlin-scripting-jvm-host').versionRef('kotlin')
+            library('kotlin-scriptingJSR223', 'org.jetbrains.kotlin', 'kotlin-scripting-jsr223').versionRef('kotlin')
+
+            library('spek-dsl', 'org.spekframework.spek2', 'spek-dsl-jvm').versionRef('spek')
+            library('spek-junit5', 'org.spekframework.spek2', 'spek-runner-junit5').versionRef('spek')
+
+            library('jupiter-api', 'org.junit.jupiter', 'junit-jupiter-api').versionRef('junitJupiter')
+            library('jupiter-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef('junitJupiter')
+
+            bundle('jupiter', ['jupiter-api', 'jupiter-engine'])
+
+            library('kotest', 'io.kotest', 'kotest-assertions-core').versionRef('kotest')
+            library('kluent', 'org.amshove.kluent', 'kluent').versionRef('kluent')
+            library('slf4j-simple', 'org.slf4j', 'slf4j-simple').versionRef('slf4j')
+            library('gson', 'com.google.code.gson', 'gson').versionRef('gson')
+            library('antlr', 'org.antlr', 'antlr4').versionRef('antlr')
+            library('antlrRuntime', 'org.antlr', 'antlr4-runtime').versionRef('antlr')
+        }
+    }
+}
+
 include 'openrndr-demos',
         'orx-jvm:orx-boofcv',
         'orx-camera',


### PR DESCRIPTION
This approach makes use of version catalogs for declaring dependencies and their versions.

All the credit goes to @hamoid, I merely cleaned it up a bit.