### PR TITLE
Fix Rectangle.grid rounding error

### DIFF
--- a/orx-shapes/src/commonMain/kotlin/RectangleGrid.kt
+++ b/orx-shapes/src/commonMain/kotlin/RectangleGrid.kt
@@ -1,6 +1,7 @@
 package org.openrndr.extra.shapes
 
 import org.openrndr.shape.Rectangle
+import kotlin.math.round
 
 /**
  * Splits [Rectangle] into a grid of [Rectangle]s
@@ -51,8 +52,8 @@ fun Rectangle.grid(
     val cellSpaceX = cellWidth + gutterX
     val cellSpaceY = cellHeight + gutterY
 
-    val columns = ((availableWidth + gutterX) / cellSpaceX).toInt()
-    val rows = ((availableHeight + gutterY) / cellSpaceY).toInt()
+    val columns = round((availableWidth + gutterX) / cellSpaceX).toInt()
+    val rows = round((availableHeight + gutterY) / cellSpaceY).toInt()
 
     if (columns == 0 || rows == 0) {
         return emptyList()


### PR DESCRIPTION
With certain margin values one would get a column or row too few.