### PR TITLE
Re-add Camera2D

### DIFF
--- a/orx-camera/build.gradle.kts
+++ b/orx-camera/build.gradle.kts
@@ -1,8 +1,26 @@
+import ScreenshotsHelper.collectScreenshots
+
 plugins {
     org.openrndr.extra.convention.`kotlin-multiplatform`
 }
 
 kotlin {
+    jvm {
+        @Suppress("UNUSED_VARIABLE")
+        val demo by compilations.getting {
+            // TODO: Move demos to /jvmDemo
+            defaultSourceSet {
+                kotlin.srcDir("src/demo/kotlin")
+            }
+            collectScreenshots { }
+        }
+        testRuns["test"].executionTask {
+            useJUnitPlatform {
+                includeEngines("spek2")
+            }
+        }
+    }
+
     sourceSets {
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
@@ -13,6 +31,13 @@ kotlin {
                 implementation(libs.openrndr.draw)
                 implementation(libs.openrndr.filter)
                 implementation(libs.kotlin.reflect)
+            }
+        }
+
+        @Suppress("UNUSED_VARIABLE")
+        val jvmDemo by getting {
+            dependencies {
+                implementation(project(":orx-camera"))
             }
         }
     }

--- a/orx-camera/src/commonMain/kotlin/Camera2D.kt
+++ b/orx-camera/src/commonMain/kotlin/Camera2D.kt
@@ -1,0 +1,36 @@
+package org.openrndr.extra.camera
+
+import org.openrndr.Extension
+import org.openrndr.Program
+import org.openrndr.draw.Drawer
+import org.openrndr.math.Matrix44
+import org.openrndr.math.transforms.buildTransform
+
+/**
+ * The [Camera2D] extension enables:
+ * - **panning** the view by moving the mouse while a mouse button is pressed
+ * - **zooming** in and out by using the mouse wheel
+ *
+ * Usage: `extend(Camera2D())`
+ */
+class Camera2D : Extension {
+    override var enabled = true
+    var view = Matrix44.IDENTITY
+    override fun setup(program: Program) {
+        program.mouse.dragged.listen {
+            view = buildTransform { translate(it.dragDisplacement) } * view
+        }
+        program.mouse.scrolled.listen {
+            val scaleFactor = 1.0 - it.rotation.y * 0.03
+            view = buildTransform {
+                translate(it.position)
+                scale(scaleFactor)
+                translate(-it.position)
+            } * view
+        }
+    }
+
+    override fun beforeDraw(drawer: Drawer, program: Program) {
+        drawer.view = view
+    }
+}

--- a/orx-camera/src/demo/kotlin/DemoCamera2D.kt
+++ b/orx-camera/src/demo/kotlin/DemoCamera2D.kt
@@ -1,0 +1,25 @@
+import org.openrndr.application
+import org.openrndr.color.ColorRGBa
+import org.openrndr.draw.loadFont
+import org.openrndr.extra.camera.Camera2D
+
+/**
+ * # Camera2D demo
+ *
+ * click and drag the mouse for panning, use the mouse wheel for zooming
+ */
+fun main() = application {
+    program {
+        val font = loadFont("demo-data/fonts/IBMPlexMono-Regular.ttf", 72.0)
+
+        extend(Camera2D())
+        extend {
+            drawer.circle(drawer.bounds.center, 300.0)
+
+            drawer.fontMap = font
+            drawer.fill = ColorRGBa.PINK
+            drawer.text("click and drag mouse", 50.0, 400.0)
+            drawer.text("use mouse wheel", 50.0, 500.0)
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/openrndr/orx/issues/237

Making jvmDemo depend on orx-camera (itself) seems to be required for me. If that's not part of the conventions-files, could it be?