### PR TITLE
[orx-triangulation] Fix typo in convex hull computation

### DIFF
--- a/orx-triangulation/src/commonMain/kotlin/DelaunayTriangulation.kt
+++ b/orx-triangulation/src/commonMain/kotlin/DelaunayTriangulation.kt
@@ -71,7 +71,7 @@ class DelaunayTriangulation(val points: List<Vector2>) {
 
     fun hull() = contour {
         for (h in delaunay.hull) {
-            moveOrLineTo(points[2 * h])
+            moveOrLineTo(points[h])
         }
         close()
     }


### PR DESCRIPTION
## Issue
Index out of bounds exception when calling `hull()`

## Explanation and fix

The `2 * h` is left from before refactoring by Edwin when an array was indexed where x and y coordinates of points were stored as two consecutive `Double`s in an array. Then `2 * h` gave the x-coordinate and `2 * h + 1` gave the y-coordinate. Now, an array storing `Vector2`s is used, so to retrieve the point one should index simply by `h`. 