### PR TITLE
Use rich version range for openrndr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build OPENRNDR
         working-directory: ./openrndr
-        run: ./gradlew publishToMavenLocal -Prelease.version=0.5.1-SNAPSHOT
+        run: ./gradlew publishToMavenLocal snapshot
 
       - name: Build ORX
         run: ./gradlew build

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build OPENRNDR
         working-directory: ./openrndr
-        run: ./gradlew publishToMavenLocal -Prelease.version=0.5.1-SNAPSHOT
+        run: ./gradlew publishToMavenLocal snapshot
 
       - name: Build ORX
         run: ./gradlew build

--- a/.github/workflows/release-candidate-to-maven-central.yml
+++ b/.github/workflows/release-candidate-to-maven-central.yml
@@ -7,26 +7,19 @@ jobs:
   release_candidate_to_maven_central:
     runs-on: ubuntu-latest
     steps:
-      - name: Get OPENRNDR release tag
-        run: echo "OPENRNDR_VERSION=$(git ls-remote --refs --tags https://github.com/openrndr/openrndr | cut --delimiter='/' --fields=3 | sort --version-sort | tail --lines=1)" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
       - name: Build ORX
-        env:
-          OPENRNDR_VERSION: ${{ env.OPENRNDR_VERSION }}
-        run: ./gradlew -POPENRNDR.version=${{ env.OPENRNDR_VERSION }} -Prelease.useLastTag=true build
+        run: ./gradlew -Prelease.useLastTag=true build
       - name: Decode
         run: |
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
       - name: Publish
-        run: ./gradlew publishToSonatype -POPENRNDR.version=${{env.OPENRNDR_VERSION}} -Prelease.useLastTag=true -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=openrndr -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        run: ./gradlew publishToSonatype -Prelease.useLastTag=true -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=openrndr -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
         env:
           OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
           OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -9,26 +9,19 @@ jobs:
   release_to_maven_central:
     runs-on: ubuntu-latest
     steps:
-      - name: Get OPENRNDR release tag
-        run: echo "OPENRNDR_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/openrndr/openrndr | cut --delimiter='/' --fields=3 | tail --lines=1)" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
       - name: Build ORX
-        env:
-          OPENRNDR_VERSION: ${{ env.OPENRNDR_VERSION }}
-        run: ./gradlew -POPENRNDR.version=${{ env.OPENRNDR_VERSION }} -Prelease.useLastTag=true build
+        run: ./gradlew -Prelease.useLastTag=true build
       - name: Decode
         run: |
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
       - name: Publish
-        run: ./gradlew publishToSonatype -POPENRNDR.version=${{env.OPENRNDR_VERSION}} -Prelease.useLastTag=true -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=openrndr -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        run: ./gradlew publishToSonatype -Prelease.useLastTag=true -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=openrndr -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
         env:
           OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
           OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# ORX (OPENRNDR EXTRA) 0.4 
+# ORX (OPENRNDR EXTRA)
 
-Note that this is a yet unreleased version of ORX. The prior released version of ORX can be found in the [ORX 0.3 branch](https://github.com/openrndr/orx/tree/orx-0.3).  
-
-A growing library of assorted data structures, algorithms and utilities.
+A growing library of assorted data structures, algorithms and utilities to
+complement [OPENRNDR](https://github.com/openrndr/openrndr).
 
 <!-- __orxListBegin__ -->
 
@@ -70,10 +69,30 @@ A growing library of assorted data structures, algorithms and utilities.
 
 # Developer notes
 
-## Create and use local builds of the library
+## Publish and use local builds of the library in your applications
 
-First build and publish OPENRNDR 0.4 SNAPSHOT (using `-Prelease.version=0.5.1-SNAPSHOT`) from the `openrndr-0.4` branch.  
+First, build and publish [OPENRNDR](https://github.com/openrndr/openrndr) to the local maven repository:
 
-run `./gradlew publishToMavenLocal -Prelease.version=0.5.1-SNAPSHOT` (or import in IntelliJ IDEA and edit the run configuration)
+Run (or import in IntelliJ IDEA and edit the run configuration).
+```sh
+# In openrndr repository
+./gradlew publishToMavenLocal snapshot
+``` 
 
-In an [`openrndr-template`](https://youtu.be/saAzoREfa90?t=787) based project set `orxUseSnapshot = true` in order to use the snapshot build.
+This command will build and publish a snapshot of the next version of the library. For example, if the current latest
+release is 0.4.2, then it will create a release named "0.4.3-SNAPSHOT" and publish it to your local maven repository.
+The exact version will be shown in the console output during the build process.
+
+Now you can run the same command again but for this repository. 
+
+```sh
+# In orx repository
+./gradlew publishToMavenLocal snapshot
+``` 
+
+It will automatically use the locally published snapshot of OPENRNDR for building ORX and will publish ORX to your local
+maven repository with the same logic as before.
+
+Once that's done, you can use the local build of ORX in
+your [openrndr-template](https://github.com/openrndr/openrndr-template) by specifying the version you published. In this
+case, it would be "0.4.3-SNAPSHOT".

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ configure(allprojects.findAll { !doNotPublish.contains(it.name) && !multiplatfor
                 from components.java
                 versionMapping {
                     allVariants {
-                        fromResolutionOf("default")
+                        fromResolutionResult()
                     }
                 }
                 groupId = "org.openrndr.extra"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 val preload: SourceSet by sourceSets.creating
 
 repositories {
-    mavenLocal()
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,18 +5,8 @@ plugins {
 val preload: SourceSet by sourceSets.creating
 
 repositories {
-    mavenCentral()
     mavenLocal()
-}
-
-val openrndrVersion: String =
-    (extra.properties["OPENRNDR.version"] as String? ?: System.getenv("OPENRNDR_VERSION"))?.removePrefix("v")
-        ?: "0.5.1-SNAPSHOT"
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.openrndr") useVersion(openrndrVersion)
-    }
+    mavenCentral()
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/component-metadata-rule.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/component-metadata-rule.gradle.kts
@@ -2,16 +2,6 @@ package org.openrndr.extra.convention
 
 addHostMachineAttributesToRuntimeConfigurations()
 
-val openrndrVersion: String =
-    (extra.properties["OPENRNDR.version"] as String? ?: System.getenv("OPENRNDR_VERSION"))?.removePrefix("v")
-        ?: "0.5.1-SNAPSHOT"
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.openrndr") useVersion(openrndrVersion)
-    }
-}
-
 dependencies {
     components {
         all<LwjglRule>()

--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-jvm.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
+    mavenLocal()
 }
 
 group = "org.openrndr.extra"

--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-jvm.gradle.kts
@@ -3,7 +3,6 @@ package org.openrndr.extra.convention
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.net.URI
 
 val libs = the<LibrariesForLibs>()
 
@@ -16,16 +15,16 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 group = "org.openrndr.extra"
 
-val main by sourceSets.getting
+val main: SourceSet by sourceSets.getting
 
 @Suppress("UNUSED_VARIABLE")
-val demo by sourceSets.creating
+val demo: SourceSet by sourceSets.creating
 
 dependencies {
     implementation(libs.kotlin.stdlib)

--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
+    mavenLocal()
 }
 
 group = "org.openrndr.extra"

--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
@@ -4,7 +4,6 @@ import CollectScreenshotsTask
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.net.URI
 
 val libs = the<LibrariesForLibs>()
 
@@ -16,8 +15,8 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 group = "org.openrndr.extra"
@@ -31,7 +30,8 @@ kotlin {
     jvm {
         jvmToolchain(libs.versions.jvmTarget.get().toInt())
         compilations {
-                        val main by getting
+            val main by getting
+
             @Suppress("UNUSED_VARIABLE")
             val demo by creating {
                 associateWith(main)
@@ -39,7 +39,7 @@ kotlin {
                     inputDir.set(output.classesDirs.singleFile)
                     runtimeDependencies.set(runtimeDependencyFiles)
                     outputDir.set(project.file(project.projectDir.toString() + "/images"))
-                    dependsOn(compileKotlinTask)
+                    dependsOn(compileTaskProvider)
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlinApi = "1.8"
 kotlinLanguage = "1.8"
 kotlin = "1.8.10"
 jvmTarget = "11"
-openrndr = { require = "[0.4.3-alpha2, 1.0.0)" }
+openrndr = { require = "[0.4.3, 1.0.0)" }
 kotlinxCoroutines = "1.6.4"
 kotlinLogging = "3.0.0"
 kotlinxSerialization = "1.5.0-RC"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlinApi = "1.8"
 kotlinLanguage = "1.8"
 kotlin = "1.8.10"
 jvmTarget = "11"
-openrndr = { require = "[0.4.3, 1.0.0)" }
+openrndr = { require = "[0.4.2, 1.0.0)" }
 kotlinxCoroutines = "1.6.4"
 kotlinLogging = "3.0.0"
 kotlinxSerialization = "1.5.0-RC"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlinApi = "1.8"
 kotlinLanguage = "1.8"
 kotlin = "1.8.10"
 jvmTarget = "11"
-openrndr = "0.0.0"
+openrndr = { require = "[0.4.3-alpha2, 1.0.0)" }
 kotlinxCoroutines = "1.6.4"
 kotlinLogging = "3.0.0"
 kotlinxSerialization = "1.5.0-RC"


### PR DESCRIPTION
Replace `fromResolutionOf("default")` with `fromResolutionResult()` for publishing jvm packages as "default" will not be a resolvable configuration in Gradle 8.0.
Remove custom dependency resolution strategy for openrndr and use a rich version range.
Fix small formatting and deprecated API usages in build scripts.
Update README with the new local maven usage and remove inaccurate info.