### PR TITLE
Fix screenshots task on Gradle 8.0

### DIFF
--- a/buildSrc/src/main/kotlin/CollectScreenShots.kt
+++ b/buildSrc/src/main/kotlin/CollectScreenShots.kt
@@ -20,7 +20,7 @@ abstract class CollectScreenshotsTask @Inject constructor() : DefaultTask() {
     @get:SkipWhenEmpty
     abstract val inputDir: DirectoryProperty
 
-    @get:Input
+    @get:InputFiles
     abstract val runtimeDependencies: Property<FileCollection>
 
     @get:OutputDirectory


### PR DESCRIPTION
CI currently seems to be failing because the collectScreenshots task's `runtimeDependencies` property isn't serializable. Marking it as `@InputFiles` seems to make Gradle understand how to serialize it.