### PR TITLE
Fix orx-rabbit-control broken URL, improve README

### DIFF
--- a/orx-jvm/orx-rabbit-control/README.md
+++ b/orx-jvm/orx-rabbit-control/README.md
@@ -1,19 +1,40 @@
 # orx-rabbit-control
 
-Automatically creates a remote UI to control your OPENRNDR program from a mobile device or a different computer. Alternative to `orx-gui`. 
+Creates a web-based remote UI to control your OPENRNDR program from a mobile device or a different computer. Alternative to `orx-gui`. 
 
-`orx-rabbit-control` uses `orx-parameters` annotations to generate a control interface, just like `orx-gui`. 
+`orx-rabbit-control` uses `orx-parameters` annotations to generate a control interface, just like `orx-gui`.
+The main difference is that with `orx-gui` the UI is shown on a layer above your program while `orx-rabbit-control` 
+shows it on a web browser (potentially on another device). Ideal for tweaking parameters on interactive installations 
+without needing to attach a mouse or keyboard to the rendering computer. It also avoids difficulties caused by 
+UIs showed on rotated displays or projections. 
 
 <a href="http://rabbitcontrol.cc">
-<img src="http://rabbitcontrol.cc/carrot-sketch-c-trans.png" width="50px"> 
+  <img src="http://rabbitcontrol.cc/carrot-sketch-c-trans.png" width="50"> 
 </a>
 
-For examples, check out the [demo](./src/demo/kotlin) folder.
+Find examples under the [demo](./src/demo/kotlin) folder.
 
+### Accessing the generated web UI
 
+Once you start a program that uses orx-rabbit-control, a QR code will be displayed on a layer above your visuals
+until someone accesses the web UI. 
 
-### Using the web client
+The UI can be accessed in a web browser in three different ways:
 
-Go to [client.rabbitcontrol.cc](http://client.rabbitcontrol.cc) and enter your IP-address and port.
+- scan the QR code with a mobile device connected to the same wireless network,
+- or click on the URL displayed in the IDE console,
+- or go to [client.rabbitcontrol.cc](http://client.rabbitcontrol.cc) and enter your IP-address and port (displayed at the end of the URL shown in the IDE console)
 
-More Info about the web client: [rabbitcontrol.cc/apps/webclient/](http://rabbitcontrol.cc/apps/webclient/)
+Once the UI is visible in a web browser one can interact with the sliders, buttons, checkboxes etc. 
+to control the OPENRNDR program remotely.
+
+More info about the web client: 
+[rabbitcontrol.cc/apps/webclient/](http://rabbitcontrol.cc/apps/webclient/)
+
+### Screenshot of a simple web UI
+
+<img src="https://rabbitcontrol.cc/apps/webclient/webclient.png" width="150">
+
+### Frequently asked questions
+
+[https://rabbitcontrol.cc/faq/](https://rabbitcontrol.cc/faq/)

--- a/orx-jvm/orx-rabbit-control/src/demo/kotlin/DemoRabbitControl.kt
+++ b/orx-jvm/orx-rabbit-control/src/demo/kotlin/DemoRabbitControl.kt
@@ -51,6 +51,7 @@ fun main() = application {
 
             @ActionParameter("Action test")
             fun clicked() {
+                d += 10.0
                 println("Clicked from RabbitControl")
             }
         }

--- a/orx-jvm/orx-rabbit-control/src/main/kotlin/RabbitControlServer.kt
+++ b/orx-jvm/orx-rabbit-control/src/main/kotlin/RabbitControlServer.kt
@@ -101,7 +101,7 @@ class RabbitControlServer(private val showQRUntilClientConnects: Boolean = true,
         val socket = Socket()
         socket.connect(InetSocketAddress("google.com", 80))
         val ip = socket.localAddress.toString().replace("/", "")
-        val clientUrlWithHash = "http://$ip:$staticFilesPort/rabbit-client/index.html/#$ip:$rcpPort"
+        val clientUrlWithHash = "http://$ip:$staticFilesPort/rabbit-client/index.html#$ip:$rcpPort"
         qrCodeImage = getQRCodeImage(barcodeText = clientUrlWithHash)
         println("RabbitControl Web Client: $clientUrlWithHash")
 


### PR DESCRIPTION
Accessing the UI via QR code or URL in the log was not possible. One `/` too many.

Add details to the readme about how to use the orx.