### PR TITLE
Fix publishing dependency version mapping

### DIFF
--- a/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/extra/convention/kotlin-multiplatform.gradle.kts
@@ -104,17 +104,33 @@ if (shouldPublish) {
             val fjdj = tasks.create("fakeJavaDocJar", Jar::class) {
                 archiveClassifier.set("javadoc")
             }
-            matching { it.name == "jvm" }.forEach { p ->
-                p as MavenPublication
-                p.artifact(fjdj)
-            }
-            all {
+            named("js") {
                 this as MavenPublication
                 versionMapping {
                     allVariants {
-                        fromResolutionOf("commonMainApiDependenciesMetadata")
+                        fromResolutionOf("jsMainResolvableDependenciesMetadata")
                     }
                 }
+            }
+            named("jvm") {
+                this as MavenPublication
+                this.artifact(fjdj)
+                versionMapping {
+                    allVariants {
+                        fromResolutionOf("jvmMainResolvableDependenciesMetadata")
+                    }
+                }
+            }
+            named("kotlinMultiplatform") {
+                this as MavenPublication
+                versionMapping {
+                    allVariants {
+                        fromResolutionOf("commonMainResolvableDependenciesMetadata")
+                    }
+                }
+            }
+            all {
+                this as MavenPublication
                 pom {
                     name.set(project.name)
                     description.set(project.name)


### PR DESCRIPTION
Current usage of `fromResolutionOf("commonMainApiDependenciesMetadata")` we use for version mapping dependencies before publishing only works as long as we don't have openrndr dependencies in jvmMain or jsMain blocks. This PR fixes that so dependency versions are always resolved correctly for all of our openrndr dependencies.