### PR TITLE
Remove .take() from demos and tests when using .sampleEquidistant()

### DIFF
--- a/orx-triangulation/src/commonTest/kotlin/TestDelaunay.kt
+++ b/orx-triangulation/src/commonTest/kotlin/TestDelaunay.kt
@@ -59,7 +59,7 @@ class TestDelaunay {
 
     @Test
     fun testNeighbors() {
-        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20).take(20)
+        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20)
         val d = Delaunay.from(c)
         for (j in c.indices) {
             assertTrue(d.neighbors(j).toList().isNotEmpty())

--- a/orx-triangulation/src/commonTest/kotlin/TestVoronoi.kt
+++ b/orx-triangulation/src/commonTest/kotlin/TestVoronoi.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class TestVoronoi {
     @Test
     fun testNeighbors() {
-        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20).take(20)
+        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20)
         val d = Delaunay.from(c)
         val v = d.voronoi(Rectangle(0.0, 0.0, 400.0, 400.0))
         for (j in c.indices) {

--- a/orx-triangulation/src/commonTest/kotlin/TestVoronoiDiagram.kt
+++ b/orx-triangulation/src/commonTest/kotlin/TestVoronoiDiagram.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 class TestVoronoiDiagram {
     @Test
     fun testNeighbors() {
-        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20).take(20)
+        val c = Circle(200.0, 200.0, 150.0).contour.equidistantPositions(20)
         val d = Delaunay.from(c)
         val v = d.voronoi(Rectangle(0.0, 0.0, 400.0, 400.0))
         for (j in c.indices) {

--- a/orx-triangulation/src/jvmDemo/kotlin/DemoDelaunay01.kt
+++ b/orx-triangulation/src/jvmDemo/kotlin/DemoDelaunay01.kt
@@ -23,7 +23,7 @@ fun main() {
                 drawer.clear(ColorRGBa.BLACK)
                 for ((i, triangle) in triangles.withIndex()) {
                     drawer.fill = ColorRGBa.PINK.shade(1.0 - i / (triangles.size * 1.2))
-                    drawer.stroke = ColorRGBa.PINK.shade( i / (triangles.size * 1.0) + 0.1)
+                    drawer.stroke = ColorRGBa.PINK.shade(i / (triangles.size * 1.0) + 0.1)
                     drawer.contour(triangle)
                 }
             }

--- a/orx-triangulation/src/jvmDemo/kotlin/DemoDelaunay02.kt
+++ b/orx-triangulation/src/jvmDemo/kotlin/DemoDelaunay02.kt
@@ -1,6 +1,5 @@
 import org.openrndr.application
 import org.openrndr.color.ColorRGBa
-import org.openrndr.extra.noise.poissonDiskSampling
 import org.openrndr.extra.noise.scatter
 import org.openrndr.extra.triangulation.delaunayTriangulation
 import org.openrndr.math.Vector2

--- a/orx-triangulation/src/jvmDemo/kotlin/DemoVoronoi03.kt
+++ b/orx-triangulation/src/jvmDemo/kotlin/DemoVoronoi03.kt
@@ -23,7 +23,7 @@ fun main() {
                         rotate(Vector3.UNIT_Z, 0.0)
                     }
                 ) }
-                val points = circles.flatMap { it.contour.equidistantPositions(16).take(16) }
+                val points = circles.flatMap { it.contour.equidistantPositions(16) }
                 drawer.circles(points, 5.0)
                 val d = points.delaunayTriangulation()
                 drawer.stroke = ColorRGBa.PINK


### PR DESCRIPTION
Needs https://github.com/openrndr/openrndr/pull/388