### PR TITLE
.gitignore add /.lwjgl folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gradle.properties
 /gui-parameters/
 /ShaderError.glsl
 /.kotlin
+/.lwjgl


### PR DESCRIPTION
It seems that this folder started to be created during the build/run only recently, maybe after the update to gradle/kotlin 2.0? On my system it contains:

* 3.3.3+5
  * x64
    * libglfw.so
    * libjemalloc.so
    * liblwjgl.so
    * liblwjgl_opengl.so
    * liblwjgl_stb.so
