### PR TITLE
[orx-composition] no fill on open contours

### DIFF
--- a/orx-composition/src/commonMain/kotlin/CompositionDrawer.kt
+++ b/orx-composition/src/commonMain/kotlin/CompositionDrawer.kt
@@ -416,8 +416,12 @@ class CompositionDrawer(documentBounds: CompositionDimensions = defaultCompositi
                 shapeNode.miterLimit = miterlimit
                 shapeNode.lineCap = lineCap
                 shapeNode.lineJoin = lineJoin
-                shapeNode.fill = fill
-                shapeNode.fillOpacity = fillOpacity
+                if(shape.contours.all { it.closed}) {
+                    shapeNode.fill = fill
+                    shapeNode.fillOpacity = fillOpacity
+                } else {
+                    shapeNode.fill = null
+                }
 
                 if (insert) {
                     cursor.children.add(shapeNode)


### PR DESCRIPTION
Possible fix for #367

Only apply a fill color if all contours in the shape are closed.

Note: when a contour is drawn by orx-composition it is converted to a shape. This shape has only one contour.

This solution does not solve all discrepancies that are present when creating shapes that combine open and closed contours, reversed and not reversed, but it does fix issue #367 and renders well behaved shapes correctly.

I did not make edge cases behave exactly like the openrndr renderer because I'm not sure yet what is the desired behavior.
