### PR TITLE
[orx-gui] Invoke onChange in Parameter Path

### DIFF
--- a/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
+++ b/orx-jvm/orx-gui/src/main/kotlin/Gui.kt
@@ -617,6 +617,7 @@ open class GUI(
                                     obj,
                                     resolvedPath
                                 )
+                                onChangeListener?.invoke(parameter.property!!.name, resolvedPath)
                             }
                         } else {
                             openFolderDialog(contextID = parameter.pathContext ?: "null") {
@@ -631,6 +632,7 @@ open class GUI(
                                     obj,
                                     resolvedPath
                                 )
+                                onChangeListener?.invoke(parameter.property!!.name, resolvedPath)
                             }
                         }
                     }


### PR DESCRIPTION
It's the only parameter type that does not trigger change events.

Without this change changes to `@PathParameter` variables can't be detected in `gui.onChange`.