### PR TITLE
[orx-gui] add `windowResizable` argument to WindowedGUI

### DIFF
--- a/orx-jvm/orx-gui/src/main/kotlin/WindowedGUI.kt
+++ b/orx-jvm/orx-gui/src/main/kotlin/WindowedGUI.kt
@@ -14,6 +14,7 @@ class WindowedGUI(
     val defaultStyles: List<StyleSheet> = defaultStyles(),
     val windowClosable: Boolean = false,
     val windowAlwaysOntop: Boolean = false,
+    val windowResizable: Boolean = false,
 ) : Extension {
     override var enabled: Boolean = true
     val gui: GUI = GUI(appearance, defaultStyles)
@@ -51,6 +52,7 @@ class WindowedGUI(
                     alwaysOnTop = windowAlwaysOntop,
                     width = appearance.barWidth,
                     height = program.height,
+                    resizable = windowResizable,
                     position = program.window.position.toInt() - IntVector2(200, 0)
                 )
             ) {


### PR DESCRIPTION
This works well for vertical resizes of WindowedGUI, but less ideal when making the window wider, because the width of the GUI is only set when the window is created, not when the window is resized.

## Simple solution

In Gui.kt set

    this.width = 100.percent // instead of appearance.barWidth.px

for `container` and `sidebar` ONLY WHEN using WindowedGui.

## Potentially better 

Stretch all inputs to match the window width (with some right margin). That requires more effort.