### PR TITLE
Patching for content scaling changes in OPENRNDR

### DIFF
--- a/orx-color/src/commonMain/kotlin/palettes/ColorSequence.kt
+++ b/orx-color/src/commonMain/kotlin/palettes/ColorSequence.kt
@@ -48,7 +48,7 @@ class ColorSequence(val colors: List<Pair<Double, ConvertibleToColorRGBa>>) {
         format: ColorFormat = ColorFormat.RGBa
     ): ColorBuffer {
         val cb = colorBuffer(width, height, type = type, format = format)
-        val rt = renderTarget(width, height) {
+        val rt = renderTarget(width, height, 1.0) {
             colorBuffer(cb)
         }
 

--- a/orx-integral-image/src/demo/kotlin/DemoFII01.kt
+++ b/orx-integral-image/src/demo/kotlin/DemoFII01.kt
@@ -15,7 +15,7 @@ fun main() = application {
     program {
         val fii = FastIntegralImage()
         val integralImage = colorBuffer(width, height, 1.0, ColorFormat.RGBa, ColorType.FLOAT32)
-        val rt = renderTarget(width, height) {
+        val rt = renderTarget(width, height, 1.0) {
             colorBuffer()
         }
         extend {

--- a/orx-integral-image/src/demo/kotlin/DemoFII02.kt
+++ b/orx-integral-image/src/demo/kotlin/DemoFII02.kt
@@ -19,7 +19,7 @@ fun main() = application {
         val image = loadImage("demo-data/images/image-001.png")
         val fii = FastIntegralImage()
         val integralImage = colorBuffer(width, height, 1.0, ColorFormat.RGBa, ColorType.FLOAT32)
-        val rt = renderTarget(width, height) {
+        val rt = renderTarget(width, height, 1.0) {
             colorBuffer()
         }
         extend {

--- a/orx-jumpflood/src/jvmDemo/kotlin/DemoDirectionField01.kt
+++ b/orx-jumpflood/src/jvmDemo/kotlin/DemoDirectionField01.kt
@@ -30,7 +30,7 @@ fun main() = application {
         }
 
         // Needs to be FLOAT32 so we can have negative values
-        val result = colorBuffer(width, height, type = ColorType.FLOAT32)
+        val result = colorBuffer(width, height, rt.contentScale, type = ColorType.FLOAT32)
         val shader = shadeStyle {
             fragmentTransform = """
                 x_fill.rgb = vec3(x_fill.rg + 0.5, x_fill.b);

--- a/orx-jumpflood/src/jvmDemo/kotlin/DemoSkeleton01.kt
+++ b/orx-jumpflood/src/jvmDemo/kotlin/DemoSkeleton01.kt
@@ -25,7 +25,7 @@ fun main() = application {
     program {
         val skeleton = Skeleton()
 
-        val input = renderTarget(width, height) {
+        val input = renderTarget(width, height, 1.0) {
             colorBuffer()
         }
         val field = input.colorBuffer(0).createEquivalent(type = ColorType.FLOAT32)

--- a/orx-jumpflood/src/jvmDemo/kotlin/DemoStraightSkeleton01.kt
+++ b/orx-jumpflood/src/jvmDemo/kotlin/DemoStraightSkeleton01.kt
@@ -25,7 +25,7 @@ fun main() = application {
     program {
         val straightSkeleton = StraightSkeleton()
 
-        val input = renderTarget(width, height) {
+        val input = renderTarget(width, height, 1.0) {
             colorBuffer()
         }
         val field = input.colorBuffer(0).createEquivalent(type = ColorType.FLOAT32)

--- a/orx-jvm/orx-boofcv/src/demo/kotlin/DemoSimplified01.kt
+++ b/orx-jvm/orx-boofcv/src/demo/kotlin/DemoSimplified01.kt
@@ -32,7 +32,7 @@ import org.openrndr.shape.ShapeContour
 fun main() = application {
     program {
         // Create a buffer where to draw something for boofcv
-        val rt = renderTarget(width, height) {
+        val rt = renderTarget(width, height, 1.0) {
             colorBuffer()
             depthBuffer()
         }

--- a/orx-jvm/orx-dnk3/src/main/kotlin/features/IrradianceSH.kt
+++ b/orx-jvm/orx-dnk3/src/main/kotlin/features/IrradianceSH.kt
@@ -72,7 +72,7 @@ private fun SceneRenderer.processIrradiance(drawer: Drawer, scene: Scene, featur
                     val position = node.worldPosition
 
                     for (side in CubemapSide.values()) {
-                        val target = renderTarget(feature.cubemapSize, feature.cubemapSize) {
+                        val target = renderTarget(feature.cubemapSize, feature.cubemapSize, 1.0) {
                             //this.colorBuffer(tempCubemap.side(side))
                             this.cubemap(tempCubemap, side)
                             this.depthBuffer(cubemapDepthBuffer)

--- a/orx-noise/src/jvmDemo/kotlin/glsl/DemoSimplexGLSL.kt
+++ b/orx-noise/src/jvmDemo/kotlin/glsl/DemoSimplexGLSL.kt
@@ -33,7 +33,7 @@ fun main() = application {
     }
     program {
         val noise = SimplexNoise3D()
-        val img = colorBuffer(width, height)
+        val img = colorBuffer(width, height, window.contentScale)
         val wav = List(21) { SinOsc() }
 
         extend {


### PR DESCRIPTION
PR for review

Some notes:
- `DemoFII01.kt` & `DemoFII02.kt` - Hard coded content scale to 1.0
- `RbfGlitch01.kt` - Above my pay grade. Commented out code for now to allow screenshots to otherwise be generated
- `SceneRenderer.processIrradiance()` - Hard coded render target creation to content scale of 1.0
-  `toColorBuffer()` - It works but probably a better way to do it
